### PR TITLE
Fetch latest std version

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Unit
         run: |
           deno cache mod.ts
-          deno test --allow-run --allow-read --allow-run --allow-net
+          deno test --allow-read --allow-run --allow-net
   linting:
     strategy:
       matrix:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Unit
         run: |
           deno cache mod.ts
-          deno test --allow-run --allow-read
+          deno test --allow-run --allow-read --allow-run --allow-net
   linting:
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ As dmm only needs to read and write to your `deps.ts`, as well as requiring netw
 
 *Install*
 ```
-$ deno install --allow-net --allow-read=deps.ts --allow-write=deps.ts https://deno.land/x/dmm@v1.0.5/mod.ts
+$ deno install --allow-net --allow-read --allow-write https://deno.land/x/dmm@v1.0.5/mod.ts
 $ dmm ...
 ```
 

--- a/deps.ts
+++ b/deps.ts
@@ -1,5 +1,3 @@
-export { VERSION as denoStdLatestVersion } from "https://deno.land/std@0.56.0/version.ts";
-
 import * as colours from "https://deno.land/std@0.56.0/fmt/colors.ts";
 export { colours };
 

--- a/dmm.ts
+++ b/dmm.ts
@@ -80,11 +80,13 @@ async function getDenoLandDatabase(): Promise<any> {
   return denoDatabase;
 }
 
-async function getStdLatestVersion (): Promise<string> {
-  const res = await fetch("https://raw.githubusercontent.com/denoland/deno_website2/master/deno_std_versions.json")
-  const versions = await res.json()
-  const latestVersion = versions[0]
-  return latestVersion
+async function getStdLatestVersion(): Promise<string> {
+  const res = await fetch(
+    "https://raw.githubusercontent.com/denoland/deno_website2/master/deno_std_versions.json",
+  );
+  const versions = await res.json();
+  const latestVersion = versions[0];
+  return latestVersion;
 }
 
 /**
@@ -105,7 +107,7 @@ async function constructModulesDataFromDeps(
   purpose: string,
 ): Promise<Module[] | boolean> {
   const denoDatabase = await getDenoLandDatabase();
-  const latestStdVersion = await getStdLatestVersion()
+  const latestStdVersion = await getStdLatestVersion();
 
   async function getLatestReleaseOfGitHubRepo(
     isStd: boolean,

--- a/tests/check_test.ts
+++ b/tests/check_test.ts
@@ -1,4 +1,5 @@
 import { assertEquals, colours } from "../deps.ts";
+import { latestStdVersion } from "./utils.ts";
 
 // Check a specific dep that can be updated
 Deno.test({
@@ -32,7 +33,7 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Comparing versions...\n" +
-        colours.yellow("fs can be updated from 0.53.0 to 0.57.0") + "\n" +
+        colours.yellow(`fs can be updated from 0.53.0 to ${latestStdVersion}`) + "\n" +
         "To update, run: \n" +
         "    dmm update fs" +
         "\n",
@@ -115,7 +116,7 @@ Deno.test({
         "Reading deps.ts to gather your dependencies...\n" +
         "Comparing versions...\n" +
         colours.yellow("drash can be updated from v1.0.0 to v1.0.5") + "\n" +
-        colours.yellow("fs can be updated from 0.53.0 to 0.57.0") + "\n" +
+        colours.yellow(`fs can be updated from 0.53.0 to ${latestStdVersion}`) + "\n" +
         "To update, run: \n" +
         "    dmm update drash fs" +
         "\n",
@@ -197,8 +198,8 @@ Deno.test({
         "Reading deps.ts to gather your dependencies...\n" +
         "Comparing versions...\n" +
         colours.yellow("drash can be updated from v1.0.0 to v1.0.5") + "\n" +
-        colours.yellow("fs can be updated from 0.53.0 to 0.57.0") + "\n" +
-        colours.yellow("fmt can be updated from v0.53.0 to v0.57.0") + "\n" +
+        colours.yellow(`fs can be updated from 0.53.0 to ${latestStdVersion}`) + "\n" +
+        colours.yellow(`fmt can be updated from v0.53.0 to v${latestStdVersion}`) + "\n" +
         "To update, run: \n" +
         "    dmm update drash fs fmt" +
         "\n",

--- a/tests/check_test.ts
+++ b/tests/check_test.ts
@@ -32,7 +32,7 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Comparing versions...\n" +
-        colours.yellow("fs can be updated from 0.53.0 to 0.56.0") + "\n" +
+        colours.yellow("fs can be updated from 0.53.0 to 0.57.0") + "\n" +
         "To update, run: \n" +
         "    dmm update fs" +
         "\n",
@@ -115,7 +115,7 @@ Deno.test({
         "Reading deps.ts to gather your dependencies...\n" +
         "Comparing versions...\n" +
         colours.yellow("drash can be updated from v1.0.0 to v1.0.5") + "\n" +
-        colours.yellow("fs can be updated from 0.53.0 to 0.56.0") + "\n" +
+        colours.yellow("fs can be updated from 0.53.0 to 0.57.0") + "\n" +
         "To update, run: \n" +
         "    dmm update drash fs" +
         "\n",
@@ -197,8 +197,8 @@ Deno.test({
         "Reading deps.ts to gather your dependencies...\n" +
         "Comparing versions...\n" +
         colours.yellow("drash can be updated from v1.0.0 to v1.0.5") + "\n" +
-        colours.yellow("fs can be updated from 0.53.0 to 0.56.0") + "\n" +
-        colours.yellow("fmt can be updated from v0.53.0 to v0.56.0") + "\n" +
+        colours.yellow("fs can be updated from 0.53.0 to 0.57.0") + "\n" +
+        colours.yellow("fmt can be updated from v0.53.0 to v0.57.0") + "\n" +
         "To update, run: \n" +
         "    dmm update drash fs fmt" +
         "\n",

--- a/tests/check_test.ts
+++ b/tests/check_test.ts
@@ -33,7 +33,8 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Comparing versions...\n" +
-        colours.yellow(`fs can be updated from 0.53.0 to ${latestStdVersion}`) + "\n" +
+        colours.yellow(`fs can be updated from 0.53.0 to ${latestStdVersion}`) +
+        "\n" +
         "To update, run: \n" +
         "    dmm update fs" +
         "\n",
@@ -116,7 +117,8 @@ Deno.test({
         "Reading deps.ts to gather your dependencies...\n" +
         "Comparing versions...\n" +
         colours.yellow("drash can be updated from v1.0.0 to v1.0.5") + "\n" +
-        colours.yellow(`fs can be updated from 0.53.0 to ${latestStdVersion}`) + "\n" +
+        colours.yellow(`fs can be updated from 0.53.0 to ${latestStdVersion}`) +
+        "\n" +
         "To update, run: \n" +
         "    dmm update drash fs" +
         "\n",
@@ -198,8 +200,11 @@ Deno.test({
         "Reading deps.ts to gather your dependencies...\n" +
         "Comparing versions...\n" +
         colours.yellow("drash can be updated from v1.0.0 to v1.0.5") + "\n" +
-        colours.yellow(`fs can be updated from 0.53.0 to ${latestStdVersion}`) + "\n" +
-        colours.yellow(`fmt can be updated from v0.53.0 to v${latestStdVersion}`) + "\n" +
+        colours.yellow(`fs can be updated from 0.53.0 to ${latestStdVersion}`) +
+        "\n" +
+        colours.yellow(
+          `fmt can be updated from v0.53.0 to v${latestStdVersion}`,
+        ) + "\n" +
         "To update, run: \n" +
         "    dmm update drash fs fmt" +
         "\n",

--- a/tests/help_test.ts
+++ b/tests/help_test.ts
@@ -15,6 +15,7 @@ Deno.test({
     const stdout = new TextDecoder("utf-8").decode(output);
     const error = await p.stderrOutput();
     const stderr = new TextDecoder("utf-8").decode(error);
+    assertEquals(stderr, "");
     assertEquals(
       stdout,
       "\n" +
@@ -45,7 +46,6 @@ Deno.test({
         "    dmm info http\n" +
         "\n",
     );
-    assertEquals(stderr, "");
     assertEquals(status.code, 0);
     assertEquals(status.success, true);
   },

--- a/tests/info_test.ts
+++ b/tests/info_test.ts
@@ -1,4 +1,5 @@
 import { assertEquals, colours } from "../deps.ts";
+import { latestStdVersion } from "./utils.ts";
 
 // Check a specific dep that can be updated
 Deno.test({
@@ -87,10 +88,10 @@ Deno.test({
         "\n" +
         "  - Name: fs\n" +
         "  - Description: Cannot retrieve descriptions for std modules\n" +
-        "  - deno.land Link: https://deno.land/std@0.57.0/fs\n" +
+        `  - deno.land Link: https://deno.land/std@${latestStdVersion}/fs\n` +
         "  - GitHub Repository: https://github.com/denoland/deno/tree/master/std/fs\n" +
-        '  - Import Statement: import * as fs from \"https://deno.land/std@0.57.0/fs\";\n' +
-        "  - Latest Version: 0.57.0\n" +
+        `  - Import Statement: import * as fs from \"https://deno.land/std@${latestStdVersion}/fs\";\n` +
+        `  - Latest Version: ${latestStdVersion}\n` +
         "\n",
     );
     assertEquals(stderr, "");

--- a/tests/info_test.ts
+++ b/tests/info_test.ts
@@ -87,10 +87,10 @@ Deno.test({
         "\n" +
         "  - Name: fs\n" +
         "  - Description: Cannot retrieve descriptions for std modules\n" +
-        "  - deno.land Link: https://deno.land/std@0.56.0/fs\n" +
+        "  - deno.land Link: https://deno.land/std@0.57.0/fs\n" +
         "  - GitHub Repository: https://github.com/denoland/deno/tree/master/std/fs\n" +
-        '  - Import Statement: import * as fs from \"https://deno.land/std@0.56.0/fs\";\n' +
-        "  - Latest Version: 0.56.0\n" +
+        '  - Import Statement: import * as fs from \"https://deno.land/std@0.57.0/fs\";\n' +
+        "  - Latest Version: 0.57.0\n" +
         "\n",
     );
     assertEquals(stderr, "");

--- a/tests/up-to-date-deps/deps.ts
+++ b/tests/up-to-date-deps/deps.ts
@@ -1,8 +1,8 @@
 import { Drash } from "https://deno.land/x/drash@v1.0.5/mod.ts"; // up to date
 
-import * as fs from "https://deno.land/std@0.56.0/fs/mod.ts"; // up to date
+import * as fs from "https://deno.land/std@0.57.0/fs/mod.ts"; // up to date
 
-import * as colors from "https://deno.land/std@0.56.0/fmt/colors.ts"; // up to date
+import * as colors from "https://deno.land/std@0.57.0/fmt/colors.ts"; // up to date
 
 import { Drash as drash } from "https://deno.land/x/drash@v1.0.5/mod.ts"; // up to date
 

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,0 +1,10 @@
+async function getLatestStdVersion () {
+  const res = await fetch(
+      "https://raw.githubusercontent.com/denoland/deno_website2/master/deno_std_versions.json",
+  );
+  const versions = await res.json();
+  const latestVersion = versions[0];
+  return latestVersion;
+}
+
+export const latestStdVersion = await getLatestStdVersion()

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,10 +1,10 @@
-async function getLatestStdVersion () {
+async function getLatestStdVersion() {
   const res = await fetch(
-      "https://raw.githubusercontent.com/denoland/deno_website2/master/deno_std_versions.json",
+    "https://raw.githubusercontent.com/denoland/deno_website2/master/deno_std_versions.json",
   );
   const versions = await res.json();
   const latestVersion = versions[0];
   return latestVersion;
 }
 
-export const latestStdVersion = await getLatestStdVersion()
+export const latestStdVersion = await getLatestStdVersion();


### PR DESCRIPTION
Currently, the latest std version is technically hard coded: `import { version } from "https://deno.land/std@v0.56.0/version.ts`, and for some reason i didn't see the problem with this, thinking 'oh the version will just need to be updated'

Now, with this new commit, it will **actually** retrieve the latest version.