### PR TITLE
upgrade deno to v1.1.1

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        deno: ["1.1.0"]
+        deno: ["1.1.1"]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ As dmm only needs to read and write to your `deps.ts`, as well as requiring netw
 
 *Install*
 ```
-$ deno install --allow-net --allow-read --allow-write https://deno.land/x/dmm@v1.1.0/mod.ts
+$ deno install --allow-net --allow-read --allow-write https://deno.land/x/dmm@v1.1.1/mod.ts
 $ dmm ...
 ```
 
@@ -58,7 +58,7 @@ $ dmm ...
 
 If you are using this method, be sure to use the latest version of dmm in the command below
 ```
-$ deno run <permissions> https://deno.land/x/dmm@v1.1.0/mod.ts ...
+$ deno run <permissions> https://deno.land/x/dmm@v1.1.1/mod.ts ...
 ```
 
 In the examples below, dmm is installed and we will be using it that way to make the commands easier to read.
@@ -78,10 +78,10 @@ Information on fmt
 
   - Name: fmt
   - Description: Cannot retrieve descriptions for std modules
-  - deno.land Link: https://deno.land/std@0.57.0/fmt
+  - deno.land Link: https://deno.land/std@0.58.0/fmt
   - GitHub Repository: https://github.com/denoland/deno/tree/master/std/fmt
-  - Import Statement: import * as fmt from "https://deno.land/std@0.57.0/fmt";
-  - Latest Version: 0.57.0
+  - Import Statement: import * as fmt from "https://deno.land/std@0.58.0/fmt";
+  - Latest Version: 0.58.0
 
 ```
 
@@ -94,7 +94,7 @@ export { Drash } from "https://deno.land/x/drash@v1.0.0/mod.ts"; // out of date
 
 import * as fs from "https://deno.land/std@0.53.0/fs/mod.ts"; // out of date
 
-import * as colors from "https://deno.land/std@0.57.0/fmt/colors.ts"; // up to date
+import * as colors from "https://deno.land/std@0.58.0/fmt/colors.ts"; // up to date
 
 export { fs, colors }
 ```
@@ -109,7 +109,7 @@ Now we want to check if any of our dependencies need updating, but we don't want
 $ dmm check
 ...
 drash can be updated from v1.0.0 to v1.0.5
-fs can be updated from 0.53.0 to 0.57.0
+fs can be updated from 0.53.0 to 0.58.0
 ...
 ```
 
@@ -121,7 +121,7 @@ Lets update our dependencies as some are out of date:
 $ dmm update
 ...
 drash was updated from v1.0.0 to v1.0.5
-fs was updated from 0.53.0 to 0.57.0
+fs was updated from 0.53.0 to 0.58.0
 ...
 ```
 
@@ -130,9 +130,9 @@ Now lets check the `deps.ts` file, and you will notice the versions have been mo
 ```typescript
 export { Drash } from "https://deno.land/x/drash@v1.0.5/mod.ts"; // was out of date
 
-import * as fs from "https://deno.land/std@0.57.0/fs/mod.ts"; // was out of date
+import * as fs from "https://deno.land/std@0.58.0/fs/mod.ts"; // was out of date
 
-import * as colors from "https://deno.land/std@0.57.0/fmt/colors.ts";
+import * as colors from "https://deno.land/std@0.58.0/fmt/colors.ts";
 
 export { fs, colors }
 ```
@@ -147,7 +147,7 @@ $ dmm --help
 A module manager for Deno.    
 
 USAGE:
-    deno run --allow-read --allow-net [--allow-write] https://deno.land/x/dmm@v1.1.0/mod.ts [ARGS] [MODULES]
+    deno run --allow-read --allow-net [--allow-write] https://deno.land/x/dmm@v1.1.1/mod.ts [ARGS] [MODULES]
 
     dmm [ARGS] [MODULES]
 
@@ -171,9 +171,9 @@ OPTIONS:
 
 EXAMPLE USAGE:
     Assume you are importing an out of date version of `fs` from `std`.
-    deno run --allow-net --allow-read https://deno.land/x/dmm@v1.1.0/mod.ts check fs
-    deno run --allow-net --allow-read --allow-write https://deno.land/x/dmm@v1.1.0/mod.ts update fs
-    deno run --allow-net https://deno.land/x/dmm@v1.1.0/mod.ts info http
+    deno run --allow-net --allow-read https://deno.land/x/dmm@v1.1.1/mod.ts check fs
+    deno run --allow-net --allow-read --allow-write https://deno.land/x/dmm@v1.1.1/mod.ts update fs
+    deno run --allow-net https://deno.land/x/dmm@v1.1.1/mod.ts info http
     dmm info http
 
 ```

--- a/src/options/help.ts
+++ b/src/options/help.ts
@@ -4,7 +4,7 @@ export const helpMessage: string = "\n" +
   "\n" +
   "USAGE:" +
   "\n" +
-  "    deno run --allow-read --allow-net [--allow-write] https://deno.land/x/dmm@v1.1.0/mod.ts [ARGS] [MODULES]" +
+  "    deno run --allow-read --allow-net [--allow-write] https://deno.land/x/dmm@v1.1.1/mod.ts [ARGS] [MODULES]" +
   "\n" +
   "\n" +
   "    dmm [ARGS] [MODULES]" +
@@ -45,11 +45,11 @@ export const helpMessage: string = "\n" +
   "\n" +
   "    Assume you are importing an out of date version of `fs` from `std`." +
   "\n" +
-  "    deno run --allow-net --allow-read https://deno.land/x/dmm@v1.1.0/mod.ts check fs" +
+  "    deno run --allow-net --allow-read https://deno.land/x/dmm@v1.1.1/mod.ts check fs" +
   "\n" +
-  "    deno run --allow-net --allow-read --allow-write https://deno.land/x/dmm@v1.1.0/mod.ts update fs" +
+  "    deno run --allow-net --allow-read --allow-write https://deno.land/x/dmm@v1.1.1/mod.ts update fs" +
   "\n" +
-  "    deno run --allow-net https://deno.land/x/dmm@v1.1.0/mod.ts info http" +
+  "    deno run --allow-net https://deno.land/x/dmm@v1.1.1/mod.ts info http" +
   "\n" +
   "    dmm info http" +
   "\n";

--- a/src/options/version.ts
+++ b/src/options/version.ts
@@ -1,2 +1,2 @@
-const version = "1.1.0";
+const version = "1.1.1";
 export const versionMessage = `dmm ${version}`;

--- a/tests/help_test.ts
+++ b/tests/help_test.ts
@@ -22,7 +22,7 @@ Deno.test({
         "A module manager for Deno.\n" +
         "\n" +
         "USAGE:\n" +
-        "    deno run --allow-read --allow-net [--allow-write] https://deno.land/x/dmm@v1.1.0/mod.ts [ARGS] [MODULES]\n" +
+        "    deno run --allow-read --allow-net [--allow-write] https://deno.land/x/dmm@v1.1.1/mod.ts [ARGS] [MODULES]\n" +
         "\n" +
         "    dmm [ARGS] [MODULES]\n" +
         "\n" +
@@ -51,9 +51,9 @@ Deno.test({
         "\n" +
         "EXAMPLE USAGE:\n" +
         "    Assume you are importing an out of date version of `fs` from `std`.\n" +
-        "    deno run --allow-net --allow-read https://deno.land/x/dmm@v1.1.0/mod.ts check fs\n" +
-        "    deno run --allow-net --allow-read --allow-write https://deno.land/x/dmm@v1.1.0/mod.ts update fs\n" +
-        "    deno run --allow-net https://deno.land/x/dmm@v1.1.0/mod.ts info http\n" +
+        "    deno run --allow-net --allow-read https://deno.land/x/dmm@v1.1.1/mod.ts check fs\n" +
+        "    deno run --allow-net --allow-read --allow-write https://deno.land/x/dmm@v1.1.1/mod.ts update fs\n" +
+        "    deno run --allow-net https://deno.land/x/dmm@v1.1.1/mod.ts info http\n" +
         "    dmm info http\n" +
         "\n",
     );

--- a/tests/update_test.ts
+++ b/tests/update_test.ts
@@ -62,7 +62,7 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Checking if your modules can be updated...\n" +
-        colours.green("fs was updated from 0.53.0 to 0.57.0") + "\n",
+        colours.green("fs was updated from 0.53.0 to 0.58.0") + "\n",
     );
     assertEquals(stderr, "");
     assertEquals(status.code, 0);
@@ -74,7 +74,7 @@ Deno.test({
       Deno.readFileSync("tests/out-of-date-deps/deps.ts"),
     );
     assertEquals(newDepContent !== originalDepContent, true);
-    assertEquals(newDepContent.indexOf("std@0.57.0/fs") !== -1, true);
+    assertEquals(newDepContent.indexOf("std@0.58.0/fs") !== -1, true);
     defaultDepsBackToOriginal("out-of-date-deps");
   },
 });
@@ -156,8 +156,8 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Checking if your modules can be updated...\n" +
-        colours.green("fs was updated from 0.53.0 to 0.57.0") + "\n" +
-        colours.green("fmt was updated from v0.53.0 to v0.57.0") + "\n",
+        colours.green("fs was updated from 0.53.0 to 0.58.0") + "\n" +
+        colours.green("fmt was updated from v0.53.0 to v0.58.0") + "\n",
     );
     assertEquals(stderr, "");
     assertEquals(status.code, 0);
@@ -169,8 +169,8 @@ Deno.test({
       Deno.readFileSync("tests/out-of-date-deps/deps.ts"),
     );
     assertEquals(newDepContent !== originalDepContent, true);
-    assertEquals(newDepContent.indexOf("std@0.57.0/fs") !== -1, true);
-    assertEquals(newDepContent.indexOf("std@v0.57.0/fmt") !== -1, true);
+    assertEquals(newDepContent.indexOf("std@0.58.0/fs") !== -1, true);
+    assertEquals(newDepContent.indexOf("std@v0.58.0/fmt") !== -1, true);
     defaultDepsBackToOriginal("out-of-date-deps");
   },
 });
@@ -250,9 +250,9 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Checking if your modules can be updated...\n" +
-        colours.green("drash was updated from v1.0.0 to v1.0.5") + "\n" +
-        colours.green("fs was updated from 0.53.0 to 0.57.0") + "\n" +
-        colours.green("fmt was updated from v0.53.0 to v0.57.0") + "\n",
+        colours.green("drash was updated from v1.0.0 to v1.0.6") + "\n" +
+        colours.green("fs was updated from 0.53.0 to 0.58.0") + "\n" +
+        colours.green("fmt was updated from v0.53.0 to v0.58.0") + "\n",
     );
     assertEquals(stderr, "");
     assertEquals(status.code, 0);
@@ -264,9 +264,9 @@ Deno.test({
       Deno.readFileSync("tests/out-of-date-deps/deps.ts"),
     );
     assertEquals(newDepContent !== originalDepContent, true);
-    assertEquals(newDepContent.indexOf("std@0.57.0/fs") !== -1, true);
-    assertEquals(newDepContent.indexOf("std@v0.57.0/fmt") !== -1, true);
-    assertEquals(newDepContent.indexOf("drash@v1.0.5") !== -1, true);
+    assertEquals(newDepContent.indexOf("std@0.58.0/fs") !== -1, true);
+    assertEquals(newDepContent.indexOf("std@v0.58.0/fmt") !== -1, true);
+    assertEquals(newDepContent.indexOf("drash@v1.0.6") !== -1, true);
     defaultDepsBackToOriginal("out-of-date-deps");
   },
 });
@@ -344,7 +344,7 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Checking if your modules can be updated...\n" +
-        colours.green("drash was updated from v1.0.0 to v1.0.5") + "\n",
+        colours.green("drash was updated from v1.0.0 to v1.0.6") + "\n",
     );
     assertEquals(stderr, "");
     assertEquals(status.code, 0);
@@ -356,7 +356,7 @@ Deno.test({
       Deno.readFileSync("tests/out-of-date-deps/deps.ts"),
     );
     assertEquals(newDepContent !== originalDepContent, true);
-    assertEquals(newDepContent.indexOf("drash@v1.0.5") !== -1, true);
+    assertEquals(newDepContent.indexOf("drash@v1.0.6") !== -1, true);
     defaultDepsBackToOriginal("out-of-date-deps");
   },
 });
@@ -438,8 +438,8 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Checking if your modules can be updated...\n" +
-        colours.green("drash was updated from v1.0.0 to v1.0.5") + "\n" +
-        colours.green("fmt was updated from v0.53.0 to v0.57.0") + "\n",
+        colours.green("drash was updated from v1.0.0 to v1.0.6") + "\n" +
+        colours.green("fmt was updated from v0.53.0 to v0.58.0") + "\n",
     );
     assertEquals(stderr, "");
     assertEquals(status.code, 0);
@@ -451,8 +451,8 @@ Deno.test({
       Deno.readFileSync("tests/out-of-date-deps/deps.ts"),
     );
     assertEquals(newDepContent !== originalDepContent, true);
-    assertEquals(newDepContent.indexOf("std@v0.57.0/fmt") !== -1, true);
-    assertEquals(newDepContent.indexOf("drash@v1.0.5") !== -1, true);
+    assertEquals(newDepContent.indexOf("std@v0.58.0/fmt") !== -1, true);
+    assertEquals(newDepContent.indexOf("drash@v1.0.6") !== -1, true);
     defaultDepsBackToOriginal("out-of-date-deps");
   },
 });
@@ -488,7 +488,7 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Checking if your modules can be updated...\n" +
-        colours.green("fs was updated from 0.53.0 to 0.57.0") + "\n",
+        colours.green("fs was updated from 0.53.0 to 0.58.0") + "\n",
     );
     assertEquals(stderr, "");
     assertEquals(status.code, 0);
@@ -500,7 +500,7 @@ Deno.test({
       Deno.readFileSync("tests/out-of-date-deps/deps.ts"),
     );
     assertEquals(newDepContent !== originalDepContent, true);
-    assertEquals(newDepContent.indexOf("std@0.57.0/fs") !== -1, true);
+    assertEquals(newDepContent.indexOf("std@0.58.0/fs") !== -1, true);
     defaultDepsBackToOriginal("out-of-date-deps");
   },
 });


### PR DESCRIPTION
Upgrades deno v1.1.1, making dmm ready for v1.0.7 release.

This came about as after fixing merge conflicts for #21 PR, tests fail with the new deno release that came out, hence merging this branch into that PR's branch