### PR TITLE
Add linter to master.yml

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -42,3 +42,5 @@ jobs:
         
       - name: Check Code FMT
         run: deno fmt --check
+      - name: Linter
+        run: deno lint --unstable


### PR DESCRIPTION
Fixes #27 

**Description**

* `deno lint` passes.
* add `deno lint --unstable` to master.yml
