### PR TITLE
Fixed JSON error for getting std version, and updated to deno v1.2.2

### DIFF
--- a/.github/workflows/bumper.yml
+++ b/.github/workflows/bumper.yml
@@ -7,7 +7,7 @@ jobs:
   update-dep:
     strategy:
       matrix:
-        deno: ["1.2.0"]
+        deno: ["1.2.2"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        deno: ["1.2.0"]
+        deno: ["1.2.2"]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -28,7 +28,7 @@ jobs:
   linting:
     strategy:
       matrix:
-        deno: ["1.2.0"]
+        deno: ["1.2.2"]
     # Doesn't need to be checked in all OS
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ Information on fmt
 
   - Name: fmt
   - Description: Cannot retrieve descriptions for std modules
-  - deno.land Link: https://deno.land/std@0.61.0/fmt
+  - deno.land Link: https://deno.land/std@0.63.0/fmt
   - GitHub Repository: https://github.com/denoland/deno/tree/master/std/fmt
-  - Import Statement: import * as fmt from "https://deno.land/std@0.61.0/fmt";
-  - Latest Version: 0.61.0
+  - Import Statement: import * as fmt from "https://deno.land/std@0.63.0/fmt";
+  - Latest Version: 0.63.0
 
 ```
 
@@ -97,7 +97,7 @@ export { Drash } from "https://deno.land/x/drash@v1.0.0/mod.ts"; // out of date
 
 import * as fs from "https://deno.land/std@0.53.0/fs/mod.ts"; // out of date
 
-import * as colors from "https://deno.land/std@0.61.0/fmt/colors.ts"; // up to date
+import * as colors from "https://deno.land/std@0.63.0/fmt/colors.ts"; // up to date
 
 export { fs, colors }
 ```
@@ -112,7 +112,7 @@ Now we want to check if any of our dependencies need updating, but we don't want
 $ dmm check
 ...
 drash can be updated from v1.0.0 to v1.1.1
-fs can be updated from 0.53.0 to 0.61.0
+fs can be updated from 0.53.0 to 0.63.0
 ...
 ```
 
@@ -124,7 +124,7 @@ Lets update our dependencies as some are out of date:
 $ dmm update
 ...
 drash was updated from v1.0.0 to v1.1.1
-fs was updated from 0.53.0 to 0.61.0
+fs was updated from 0.53.0 to 0.63.0
 ...
 ```
 
@@ -133,9 +133,9 @@ Now lets check the `deps.ts` file, and you will notice the versions have been mo
 ```typescript
 export { Drash } from "https://deno.land/x/drash@v1.1.1/mod.ts"; // was out of date
 
-import * as fs from "https://deno.land/std@0.61.0/fs/mod.ts"; // was out of date
+import * as fs from "https://deno.land/std@0.63.0/fs/mod.ts"; // was out of date
 
-import * as colors from "https://deno.land/std@0.61.0/fmt/colors.ts";
+import * as colors from "https://deno.land/std@0.63.0/fmt/colors.ts";
 
 export { fs, colors }
 ```

--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,4 @@
-import * as colours from "https://deno.land/std@0.61.0/fmt/colors.ts";
+import * as colours from "https://deno.land/std@0.63.0/fmt/colors.ts";
 export { colours };
 
-export { assertEquals } from "https://deno.land/std@0.61.0/testing/asserts.ts";
+export { assertEquals } from "https://deno.land/std@0.63.0/testing/asserts.ts";

--- a/src/services/deno_service.ts
+++ b/src/services/deno_service.ts
@@ -18,8 +18,8 @@ async function getLatestStdRelease(): Promise<string> {
     "https://raw.githubusercontent.com/denoland/deno_website2/master/versions.json",
   );
   const versions: {
-    std: string[],
-    cli_to_std: {[key: string]: string }
+    std: string[];
+    cli_to_std: { [key: string]: string };
   } = await res.json(); // { std: ["0.63.0", ...], cli_to_std: { v1.2.2: "0.63.0", ... } }
   const latestVersion = versions.std[0];
   return latestVersion;

--- a/src/services/deno_service.ts
+++ b/src/services/deno_service.ts
@@ -15,10 +15,13 @@ interface DenoLandDatabase {
  */
 async function getLatestStdRelease(): Promise<string> {
   const res = await fetch(
-    "https://raw.githubusercontent.com/denoland/deno_website2/master/deno_std_versions.json",
+    "https://raw.githubusercontent.com/denoland/deno_website2/master/versions.json",
   );
-  const versions: string[] = await res.json();
-  let latestVersion = versions[0];
+  const versions: {
+    std: string[],
+    cli_to_std: {[key: string]: string }
+  } = await res.json(); // { std: ["0.63.0", ...], cli_to_std: { v1.2.2: "0.63.0", ... } }
+  const latestVersion = versions.std[0];
   return latestVersion;
 }
 

--- a/tests/check_test.ts
+++ b/tests/check_test.ts
@@ -118,7 +118,7 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Comparing versions...\n" +
-        colours.yellow("drash can be updated from v1.0.0 to v1.1.1") + "\n" +
+        colours.yellow("drash can be updated from v1.0.0 to v1.2.1") + "\n" +
         colours.yellow(
           `fs can be updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
         ) +
@@ -203,7 +203,7 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Comparing versions...\n" +
-        colours.yellow("drash can be updated from v1.0.0 to v1.1.1") + "\n" +
+        colours.yellow("drash can be updated from v1.0.0 to v1.2.1") + "\n" +
         colours.yellow(
           `fs can be updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
         ) +

--- a/tests/info_test.ts
+++ b/tests/info_test.ts
@@ -56,10 +56,10 @@ Deno.test({
         "\n" +
         "  - Name: drash\n" +
         "  - Description: A REST microframework for Deno's HTTP server with zero dependencies.\n" +
-        "  - deno.land Link: https://deno.land/x/drash@v1.1.1\n" +
+        "  - deno.land Link: https://deno.land/x/drash@v1.2.1\n" +
         "  - GitHub Repository: https://github.com/drashland/deno-drash\n" +
-        '  - Import Statement: import * as drash from \"https://deno.land/x/drash@v1.1.1\";\n' +
-        "  - Latest Version: v1.1.1\n" +
+        '  - Import Statement: import * as drash from \"https://deno.land/x/drash@v1.2.1\";\n' +
+        "  - Latest Version: v1.2.1\n" +
         "\n",
     );
     assertEquals(stderr, "");

--- a/tests/up-to-date-deps/deps.ts
+++ b/tests/up-to-date-deps/deps.ts
@@ -1,9 +1,9 @@
-import { Drash } from "https://deno.land/x/drash@v1.1.1/mod.ts"; // up to date
+import { Drash } from "https://deno.land/x/drash@v1.2.1/mod.ts"; // up to date
 
-import * as fs from "https://deno.land/std@0.61.0/fs/mod.ts"; // up to date
+import * as fs from "https://deno.land/std@0.63.0/fs/mod.ts"; // up to date
 
-import * as colors from "https://deno.land/std@0.61.0/fmt/colors.ts"; // up to date
+import * as colors from "https://deno.land/std@0.63.0/fmt/colors.ts"; // up to date
 
-import { Drash as drash } from "https://deno.land/x/drash@v1.1.1/mod.ts"; // up to date
+import { Drash as drash } from "https://deno.land/x/drash@v1.2.1/mod.ts"; // up to date
 
 export { Drash, fs, colors };

--- a/tests/up-to-date-deps/original_deps.ts
+++ b/tests/up-to-date-deps/original_deps.ts
@@ -1,7 +1,7 @@
-import { Drash } from "https://deno.land/x/drash@v1.1.1/mod.ts"; // up to date
+import { Drash } from "https://deno.land/x/drash@v1.2.1/mod.ts"; // up to date
 
-import * as fs from "https://deno.land/std@0.61.0/fs/mod.ts"; // up to date
+import * as fs from "https://deno.land/std@0.63.0/fs/mod.ts"; // up to date
 
-import * as colors from "https://deno.land/std@0.61.0/fmt/colors.ts"; // up to date
+import * as colors from "https://deno.land/std@0.63.0/fmt/colors.ts"; // up to date
 
 export { Drash, fs, colors };

--- a/tests/update_test.ts
+++ b/tests/update_test.ts
@@ -60,7 +60,7 @@ Deno.test({
     const expected = "Gathering facts...\n" +
       "Reading deps.ts to gather your dependencies...\n" +
       "Checking if your modules can be updated...\n" +
-      colours.green("fs was updated from 0.53.0 to 0.61.0") + "\n";
+      colours.green("fs was updated from 0.53.0 to 0.63.0") + "\n";
     assertEquals(
       stdout,
       expected,
@@ -75,7 +75,7 @@ Deno.test({
       Deno.readFileSync("tests/out-of-date-deps/deps.ts"),
     );
     assertEquals(newDepContent !== originalDepContent, true);
-    assertEquals(newDepContent.indexOf("std@0.61.0/fs") !== -1, true);
+    assertEquals(newDepContent.indexOf("std@0.63.0/fs") !== -1, true);
     defaultDepsBackToOriginal("out-of-date-deps");
   },
 });
@@ -157,8 +157,8 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Checking if your modules can be updated...\n" +
-        colours.green("fs was updated from 0.53.0 to 0.61.0") + "\n" +
-        colours.green("fmt was updated from v0.53.0 to v0.61.0") + "\n",
+        colours.green("fs was updated from 0.53.0 to 0.63.0") + "\n" +
+        colours.green("fmt was updated from v0.53.0 to v0.63.0") + "\n",
     );
     assertEquals(stderr, "");
     assertEquals(status.code, 0);
@@ -170,8 +170,8 @@ Deno.test({
       Deno.readFileSync("tests/out-of-date-deps/deps.ts"),
     );
     assertEquals(newDepContent !== originalDepContent, true);
-    assertEquals(newDepContent.indexOf("std@0.61.0/fs") !== -1, true);
-    assertEquals(newDepContent.indexOf("std@v0.61.0/fmt") !== -1, true);
+    assertEquals(newDepContent.indexOf("std@0.63.0/fs") !== -1, true);
+    assertEquals(newDepContent.indexOf("std@v0.63.0/fmt") !== -1, true);
     defaultDepsBackToOriginal("out-of-date-deps");
   },
 });
@@ -246,15 +246,14 @@ Deno.test({
     const stdout = new TextDecoder("utf-8").decode(output);
     const error = await p.stderrOutput();
     const stderr = new TextDecoder("utf-8").decode(error);
-    assertEquals(
-      stdout,
-      "Gathering facts...\n" +
+    const assertedOutput =
+        "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Checking if your modules can be updated...\n" +
-        colours.green("drash was updated from v1.0.0 to v1.1.1") + "\n" +
-        colours.green("fs was updated from 0.53.0 to 0.61.0") + "\n" +
-        colours.green("fmt was updated from v0.53.0 to v0.61.0") + "\n",
-    );
+        colours.green("drash was updated from v1.0.0 to v1.2.1") + "\n" +
+        colours.green("fs was updated from 0.53.0 to 0.63.0") + "\n" +
+        colours.green("fmt was updated from v0.53.0 to v0.63.0") + "\n";
+    assertEquals(stdout, assertedOutput);
     assertEquals(stderr, "");
     assertEquals(status.code, 0);
     assertEquals(status.success, true);
@@ -265,9 +264,9 @@ Deno.test({
       Deno.readFileSync("tests/out-of-date-deps/deps.ts"),
     );
     assertEquals(newDepContent !== originalDepContent, true);
-    assertEquals(newDepContent.indexOf("std@0.61.0/fs") !== -1, true);
-    assertEquals(newDepContent.indexOf("std@v0.61.0/fmt") !== -1, true);
-    assertEquals(newDepContent.indexOf("drash@v1.1.1") !== -1, true);
+    assertEquals(newDepContent.indexOf("std@0.63.0/fs") !== -1, true);
+    assertEquals(newDepContent.indexOf("std@v0.63.0/fmt") !== -1, true);
+    assertEquals(newDepContent.indexOf("drash@v1.2.1") !== -1, true);
     defaultDepsBackToOriginal("out-of-date-deps");
   },
 });
@@ -345,7 +344,7 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Checking if your modules can be updated...\n" +
-        colours.green("drash was updated from v1.0.0 to v1.1.1") + "\n",
+        colours.green("drash was updated from v1.0.0 to v1.2.1") + "\n",
     );
     assertEquals(stderr, "");
     assertEquals(status.code, 0);
@@ -357,7 +356,7 @@ Deno.test({
       Deno.readFileSync("tests/out-of-date-deps/deps.ts"),
     );
     assertEquals(newDepContent !== originalDepContent, true);
-    assertEquals(newDepContent.indexOf("drash@v1.1.1") !== -1, true);
+    assertEquals(newDepContent.indexOf("drash@v1.2.1") !== -1, true);
     defaultDepsBackToOriginal("out-of-date-deps");
   },
 });
@@ -439,8 +438,8 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Checking if your modules can be updated...\n" +
-        colours.green("drash was updated from v1.0.0 to v1.1.1") + "\n" +
-        colours.green("fmt was updated from v0.53.0 to v0.61.0") + "\n",
+        colours.green("drash was updated from v1.0.0 to v1.2.1") + "\n" +
+        colours.green("fmt was updated from v0.53.0 to v0.63.0") + "\n",
     );
     assertEquals(stderr, "");
     assertEquals(status.code, 0);
@@ -452,8 +451,8 @@ Deno.test({
       Deno.readFileSync("tests/out-of-date-deps/deps.ts"),
     );
     assertEquals(newDepContent !== originalDepContent, true);
-    assertEquals(newDepContent.indexOf("std@v0.61.0/fmt") !== -1, true);
-    assertEquals(newDepContent.indexOf("drash@v1.1.1") !== -1, true);
+    assertEquals(newDepContent.indexOf("std@v0.63.0/fmt") !== -1, true);
+    assertEquals(newDepContent.indexOf("drash@v1.2.1") !== -1, true);
     defaultDepsBackToOriginal("out-of-date-deps");
   },
 });
@@ -489,7 +488,7 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Checking if your modules can be updated...\n" +
-        colours.green("fs was updated from 0.53.0 to 0.61.0") + "\n",
+        colours.green("fs was updated from 0.53.0 to 0.63.0") + "\n",
     );
     assertEquals(stderr, "");
     assertEquals(status.code, 0);
@@ -501,7 +500,7 @@ Deno.test({
       Deno.readFileSync("tests/out-of-date-deps/deps.ts"),
     );
     assertEquals(newDepContent !== originalDepContent, true);
-    assertEquals(newDepContent.indexOf("std@0.61.0/fs") !== -1, true);
+    assertEquals(newDepContent.indexOf("std@0.63.0/fs") !== -1, true);
     defaultDepsBackToOriginal("out-of-date-deps");
   },
 });

--- a/tests/update_test.ts
+++ b/tests/update_test.ts
@@ -246,13 +246,12 @@ Deno.test({
     const stdout = new TextDecoder("utf-8").decode(output);
     const error = await p.stderrOutput();
     const stderr = new TextDecoder("utf-8").decode(error);
-    const assertedOutput =
-        "Gathering facts...\n" +
-        "Reading deps.ts to gather your dependencies...\n" +
-        "Checking if your modules can be updated...\n" +
-        colours.green("drash was updated from v1.0.0 to v1.2.1") + "\n" +
-        colours.green("fs was updated from 0.53.0 to 0.63.0") + "\n" +
-        colours.green("fmt was updated from v0.53.0 to v0.63.0") + "\n";
+    const assertedOutput = "Gathering facts...\n" +
+      "Reading deps.ts to gather your dependencies...\n" +
+      "Checking if your modules can be updated...\n" +
+      colours.green("drash was updated from v1.0.0 to v1.2.1") + "\n" +
+      colours.green("fs was updated from 0.53.0 to 0.63.0") + "\n" +
+      colours.green("fmt was updated from v0.53.0 to v0.63.0") + "\n";
     assertEquals(stdout, assertedOutput);
     assertEquals(stderr, "");
     assertEquals(status.code, 0);


### PR DESCRIPTION
Fixes #<issue number>

**Description**

* Dmm failed for Rhum, so there was an internal problem. Turns out deno renamed a file for deno_website2, so adjusting this fixed the problems.

* As a result, tests needed to be fixed and std versions needed to be updated, so this PR is also an `update-dependencies` PR