### PR TITLE
Fix import

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,11 +201,11 @@ dmm will only read modules that reside on [deno.land](https://deno.land), whethe
 * dmm will read every `from "https://deno.land/..."` line in your `deps.ts` and using the name and version, will convert the dependencies into objects.
 
 * dmm will then retrieve the rest of the required information for later use for each module:
-    * Latest version - for 3rd party modules, it's taken from using the GitHub API for Deno's `database.json` file. For `std` modules, it's taken from `https://deno.land/std/@<latest version>/version.ts`
+    * Latest version - for 3rd party modules, it's pulled using `https://github.com/owner/repo/releases/latest`. For `std` modules, it's taken from `https://raw.githubusercontent.com/denoland/deno_website2/master/versions.json`
     * GitHub URL - Retrieved through the GitHub API
     * Description - For 3rd party modules, it is also taken from reading Deno's `database.json` file, which holds all modules that display on https://deno.land/x/
     
-* After this, dmm will un different actions based on the purpose:
+* After this, dmm will run different actions based on the purpose:
 
     * **check**
     

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -14,9 +14,9 @@ export async function info(modules: string[]) {
   const stdResponse = await fetch(
     "https://github.com/denoland/deno/tree/master/std/" + moduleToGetInfoOn,
   );
+  const thirdPartyResponse = await fetch("https://cdn.deno.land/" + moduleToGetInfoOn + "/meta/versions.json"); // Only used so we can check if the module exists
   const isStd = stdResponse.status === 200;
-  const denoLandDatabase = DenoService.getDenoLandDatabase();
-  const isThirdParty = typeof denoLandDatabase[moduleToGetInfoOn] === "object";
+  const isThirdParty = thirdPartyResponse.status === 200
   if (!isStd && !isThirdParty) {
     console.error(
       colours.red("No module was found with " + moduleToGetInfoOn),
@@ -36,10 +36,8 @@ export async function info(modules: string[]) {
     gitHubUrl = "https://github.com/denoland/deno/tree/master/std/" + name;
   }
   if (isThirdParty) {
-    const databaseModule = denoLandDatabase[moduleToGetInfoOn];
-    description = databaseModule.desc;
-    gitHubUrl = "https://github.com/" + databaseModule.owner + "/" +
-      databaseModule.repo;
+    description = await DenoService.getThirdPartyDescription(name);
+    gitHubUrl = "https://github.com/" + await DenoService.getThirdPartyRepoAndOwner(name)
     latestVersion = await DenoService.getLatestThirdPartyRelease(name);
     denoLandUrl = "https://deno.land/x/" + name + "@" + latestVersion;
   }

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -14,9 +14,11 @@ export async function info(modules: string[]) {
   const stdResponse = await fetch(
     "https://github.com/denoland/deno/tree/master/std/" + moduleToGetInfoOn,
   );
-  const thirdPartyResponse = await fetch("https://cdn.deno.land/" + moduleToGetInfoOn + "/meta/versions.json"); // Only used so we can check if the module exists
+  const thirdPartyResponse = await fetch(
+    "https://cdn.deno.land/" + moduleToGetInfoOn + "/meta/versions.json",
+  ); // Only used so we can check if the module exists
   const isStd = stdResponse.status === 200;
-  const isThirdParty = thirdPartyResponse.status === 200
+  const isThirdParty = thirdPartyResponse.status === 200;
   if (!isStd && !isThirdParty) {
     console.error(
       colours.red("No module was found with " + moduleToGetInfoOn),
@@ -37,7 +39,8 @@ export async function info(modules: string[]) {
   }
   if (isThirdParty) {
     description = await DenoService.getThirdPartyDescription(name);
-    gitHubUrl = "https://github.com/" + await DenoService.getThirdPartyRepoAndOwner(name)
+    gitHubUrl = "https://github.com/" +
+      await DenoService.getThirdPartyRepoAndOwner(name);
     latestVersion = await DenoService.getLatestThirdPartyRelease(name);
     denoLandUrl = "https://deno.land/x/" + name + "@" + latestVersion;
   }

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -15,7 +15,7 @@ export async function info(modules: string[]) {
     "https://github.com/denoland/deno/tree/master/std/" + moduleToGetInfoOn,
   );
   const thirdPartyResponse = await fetch(
-    "https://cdn.deno.land/" + moduleToGetInfoOn + "/meta/versions.json",
+    DenoService.DENO_CDN_URL + moduleToGetInfoOn + "/meta/versions.json",
   ); // Only used so we can check if the module exists
   const isStd = stdResponse.status === 200;
   const isThirdParty = thirdPartyResponse.status === 200;

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -34,6 +34,11 @@ export async function update(dependencies: string[]): Promise<void> {
         "std@" + module.importedVersion + "/" + module.name,
         "std@" + module.latestRelease + "/" + module.name,
       );
+      // `v` is not supported for std imports anymore
+      // TODO(edward) add tests
+      if (module.importedVersion.indexOf("v") > -1) {
+        console.warn(colours.yellow(`You are importing a version of ${module.name} prefixed with "v". deno.land does not support this and will throw a 403 error.`))
+      }
     } else {
       depsContent = depsContent.replace(
         module.name + "@" + module.importedVersion,

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -35,7 +35,6 @@ export async function update(dependencies: string[]): Promise<void> {
         "std@" + module.latestRelease + "/" + module.name,
       );
       // `v` is not supported for std imports anymore
-      // TODO(edward) add tests
       if (module.importedVersion.indexOf("v") > -1) {
         console.warn(colours.yellow(`You are importing a version of ${module.name} prefixed with "v". deno.land does not support this and will throw a 403 error.`))
       }

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -36,7 +36,11 @@ export async function update(dependencies: string[]): Promise<void> {
       );
       // `v` is not supported for std imports anymore
       if (module.importedVersion.indexOf("v") > -1) {
-        console.warn(colours.yellow(`You are importing a version of ${module.name} prefixed with "v". deno.land does not support this and will throw a 403 error.`))
+        console.warn(
+          colours.yellow(
+            `You are importing a version of ${module.name} prefixed with "v". deno.land does not support this and will throw a 403 error.`,
+          ),
+        );
       }
     } else {
       depsContent = depsContent.replace(

--- a/src/services/deno_service.ts
+++ b/src/services/deno_service.ts
@@ -21,6 +21,16 @@ const latestStdRelease = await getLatestStdRelease();
 
 export default class DenoService {
   /**
+   * Url for Deno's CDN link
+   */
+  public static readonly DENO_CDN_URL: string = "https://cdn.deno.land/";
+
+  /**
+   * Url for Deno's API link
+   */
+  public static readonly DENO_API_URL: string = "https://api.deno.land/";
+
+  /**
    * Fetches the latest release of a module using deno.land cdn.
    *
    * @param name - Module name
@@ -31,7 +41,7 @@ export default class DenoService {
     name: string,
   ): Promise<string> {
     const res = await fetch(
-      "https://cdn.deno.land/" + name + "/meta/versions.json",
+      DenoService.DENO_CDN_URL + name + "/meta/versions.json",
     );
     const json: { latest: string; versions: string[] } = await res.json();
     const latestRelease = json.latest;
@@ -61,7 +71,7 @@ export default class DenoService {
     importedModuleName: string,
   ): Promise<string> {
     const res = await fetch(
-      "https://api.deno.land/modules?query={module:" + importedModuleName +
+      DenoService.DENO_API_URL + "modules?query={module:" + importedModuleName +
         "}&limit=1",
     );
     const json: {
@@ -96,7 +106,7 @@ export default class DenoService {
       importedModuleName,
     );
     const res = await fetch(
-      "https://cdn.deno.land/" + importedModuleName + "/versions/" +
+      DenoService.DENO_CDN_URL + importedModuleName + "/versions/" +
         latestRelease + "/meta/meta.json",
     );
     const json: {

--- a/src/services/deno_service.ts
+++ b/src/services/deno_service.ts
@@ -33,8 +33,8 @@ export default class DenoService {
     const res = await fetch(
       "https://cdn.deno.land/" + name + "/meta/versions.json",
     );
-    const json: { latest: string, versions: string[] } = await res.json()
-    const latestRelease = json.latest
+    const json: { latest: string; versions: string[] } = await res.json();
+    const latestRelease = json.latest;
     return latestRelease;
   }
 
@@ -57,22 +57,27 @@ export default class DenoService {
    *
    * @returns The description
    */
-  public static async getThirdPartyDescription (importedModuleName: string): Promise<string> {
-    const res = await fetch("https://api.deno.land/modules?query={module:" + importedModuleName + "}&limit=1")
+  public static async getThirdPartyDescription(
+    importedModuleName: string,
+  ): Promise<string> {
+    const res = await fetch(
+      "https://api.deno.land/modules?query={module:" + importedModuleName +
+        "}&limit=1",
+    );
     const json: {
-      success: boolean,
+      success: boolean;
       data: {
-        total_count: number,
+        total_count: number;
         results: Array<{
-          name: string,
-          description: string,
-          star_count: number,
-          search_score: number
-        }>
-      }
-    } = await res.json()
-    const description = json.data.results[0].description
-    return description
+          name: string;
+          description: string;
+          star_count: number;
+          search_score: number;
+        }>;
+      };
+    } = await res.json();
+    const description = json.data.results[0].description;
+    return description;
   }
 
   /**
@@ -84,15 +89,22 @@ export default class DenoService {
    *
    * @returns The owner and repo name, eg "<owner>/<repo>"
    */
-  public static async getThirdPartyRepoAndOwner (importedModuleName: string): Promise<string> {
-    const latestRelease = await DenoService.getLatestThirdPartyRelease(importedModuleName)
-    const res = await fetch("https://cdn.deno.land/" + importedModuleName + "/versions/" + latestRelease + "/meta/meta.json")
+  public static async getThirdPartyRepoAndOwner(
+    importedModuleName: string,
+  ): Promise<string> {
+    const latestRelease = await DenoService.getLatestThirdPartyRelease(
+      importedModuleName,
+    );
+    const res = await fetch(
+      "https://cdn.deno.land/" + importedModuleName + "/versions/" +
+        latestRelease + "/meta/meta.json",
+    );
     const json: {
       upload_options: {
-        repository: string
-      }
-    } = await res.json()
-    const repository = json.upload_options.repository
-    return repository
+        repository: string;
+      };
+    } = await res.json();
+    const repository = json.upload_options.repository;
+    return repository;
   }
 }

--- a/src/services/deno_service.ts
+++ b/src/services/deno_service.ts
@@ -1,12 +1,3 @@
-interface DenoLandDatabase {
-  [key: string]: {
-    name: string;
-    repo: string;
-    desc: string;
-    owner: string;
-  };
-}
-
 /**
  * @description
  * Fetches the latest std version
@@ -19,52 +10,32 @@ async function getLatestStdRelease(): Promise<string> {
   );
   const versions: {
     std: string[];
+    cli: string[];
     cli_to_std: { [key: string]: string };
-  } = await res.json(); // { std: ["0.63.0", ...], cli_to_std: { v1.2.2: "0.63.0", ... } }
+  } = await res.json(); // { std: ["0.63.0", ...], cli: ["v1.2.2", ...], cli_to_std: { v1.2.2: "0.63.0", ... } }
+  console.log(versions.std[0])
   const latestVersion = versions.std[0];
   return latestVersion;
 }
 
 const latestStdRelease = await getLatestStdRelease();
 
-/**
- * @description
- * Fetches Deno's `database.json` from the `deno_website2` GitHub repo
- *
- * @return {Promise<[key: string]: DenoLandDatabaseModule>} All 3rd party modules in Deno's registry
- */
-async function getDenoLandDatabase(): Promise<DenoLandDatabase> {
-  const res = await fetch(
-    "https://raw.githubusercontent.com/denoland/deno_website2/master/database.json",
-  );
-  const denoDatabase: DenoLandDatabase = await res.json();
-  return denoDatabase;
-}
-
-const denoLandDatabase: DenoLandDatabase = await getDenoLandDatabase();
-
 export default class DenoService {
   /**
-   * @description
-   * Fetches the latest release of a module from it's GitHub repository.
-   * Achieves this by reading Deno's `database.json` to get the repository name
-   * and owner then sending a fetch request.
+   * Fetches the latest release of a module using deno.land cdn.
    *
-   * @param {string} name Module name
+   * @param name - Module name
    *
-   * @returns {Promise<string>} The latest version.
+   * @returns The latest version.
    */
   public static async getLatestThirdPartyRelease(
     name: string,
   ): Promise<string> {
-    const owner = denoLandDatabase[name].owner;
-    const repo = denoLandDatabase[name].repo;
     const res = await fetch(
-      "https://github.com/" + owner + "/" + repo + "/releases/latest",
+      "https://cdn.deno.land/" + name + "/meta/versions.json",
     );
-    const url = res.url;
-    const urlSplit = url.split("/");
-    let latestRelease = urlSplit[urlSplit.length - 1];
+    const json: { latest_release: string, versions: string[] } = await res.json()
+    const latestRelease = json.latest_release
     return latestRelease;
   }
 
@@ -79,12 +50,50 @@ export default class DenoService {
   }
 
   /**
-   * @description
-   * Get JSON file of 3rd party modules on deno.land
+   * Fetches the description for a module
    *
-   * @returns {DenoLandDatabase}
+   *     await getThirdPartyDescription("drash"); // "A REST microframework ..."
+   *
+   * @param importedModuleName - The imported module in which we want to get the description for
+   *
+   * @returns The description
    */
-  public static getDenoLandDatabase(): DenoLandDatabase {
-    return denoLandDatabase;
+  public static async getThirdPartyDescription (importedModuleName: string): Promise<string> {
+    const res = await fetch("https://api.deno.land/modules?query={module:" + importedModuleName + "}&limit=1")
+    const json: {
+      success: boolean,
+      data: {
+        total_count: number,
+        results: Array<{
+          name: string,
+          description: string,
+          star_count: number,
+          search_score: number
+        }>
+      }
+    } = await res.json()
+    const description = json.data.results[0].description
+    return description
+  }
+
+  /**
+   * Fetches the owner and repository name, for the given module
+   *
+   *     await getThirdPartyRepoAndOwner("drash"); // "drashland/deno-drash"
+   *
+   * @param importedModuleName - The imported module in which we want to get the repository for on github
+   *
+   * @returns The owner and repo name, eg "<owner>/<repo>"
+   */
+  public static async getThirdPartyRepoAndOwner (importedModuleName: string): Promise<string> {
+    const latestRelease = await DenoService.getLatestThirdPartyRelease(importedModuleName)
+    const res = await fetch("https://cdn.deno.land/" + importedModuleName + "/versions/" + latestRelease + "/meta/meta.json")
+    const json: {
+      upload_options: {
+        repository: string
+      }
+    } = await res.json()
+    const repository = json.upload_options.repository
+    return repository
   }
 }

--- a/src/services/deno_service.ts
+++ b/src/services/deno_service.ts
@@ -13,7 +13,6 @@ async function getLatestStdRelease(): Promise<string> {
     cli: string[];
     cli_to_std: { [key: string]: string };
   } = await res.json(); // { std: ["0.63.0", ...], cli: ["v1.2.2", ...], cli_to_std: { v1.2.2: "0.63.0", ... } }
-  console.log(versions.std[0])
   const latestVersion = versions.std[0];
   return latestVersion;
 }
@@ -34,8 +33,8 @@ export default class DenoService {
     const res = await fetch(
       "https://cdn.deno.land/" + name + "/meta/versions.json",
     );
-    const json: { latest_release: string, versions: string[] } = await res.json()
-    const latestRelease = json.latest_release
+    const json: { latest: string, versions: string[] } = await res.json()
+    const latestRelease = json.latest
     return latestRelease;
   }
 

--- a/src/services/module_service.ts
+++ b/src/services/module_service.ts
@@ -107,7 +107,8 @@ export default class ModuleService {
       // Get the github url
       const githubURL: string = std === true
         ? "https://github.com/denoland/deno/tree/master/std/" + name
-        : "https://github.com/" + await DenoService.getThirdPartyRepoAndOwner(name);
+        : "https://github.com/" +
+          await DenoService.getThirdPartyRepoAndOwner(name);
 
       // Get the latest release - make sure the string is the same format as imported version eg using a "v"
       const latestRelease: string = std === true

--- a/src/services/module_service.ts
+++ b/src/services/module_service.ts
@@ -105,11 +105,9 @@ export default class ModuleService {
       }
 
       // Get the github url
-      const denoLandDatabase = DenoService.getDenoLandDatabase();
       const githubURL: string = std === true
         ? "https://github.com/denoland/deno/tree/master/std/" + name
-        : "https://github.com/" + denoLandDatabase[name].owner + "/" +
-          denoLandDatabase[name].repo;
+        : "https://github.com/" + await DenoService.getThirdPartyRepoAndOwner(name);
 
       // Get the latest release - make sure the string is the same format as imported version eg using a "v"
       const latestRelease: string = std === true
@@ -124,7 +122,7 @@ export default class ModuleService {
 
       // Get the description
       const description: string = std === false
-        ? denoLandDatabase[name].desc
+        ? await DenoService.getThirdPartyDescription(name)
         : colours.red(
           "Descriptions for std modules are not currently supported",
         );

--- a/tests/check_test.ts
+++ b/tests/check_test.ts
@@ -211,7 +211,7 @@ Deno.test({
         ) +
         "\n" +
         colours.yellow(
-          `fmt can be updated from 0.53.0 to v${DenoService.getLatestStdRelease()}`,
+          `fmt can be updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
         ) + "\n" +
         "To update, run: \n" +
         "    dmm update drash fs fmt" +

--- a/tests/check_test.ts
+++ b/tests/check_test.ts
@@ -1,6 +1,8 @@
 import { assertEquals, colours } from "../deps.ts";
 import DenoService from "../src/services/deno_service.ts";
 
+const latestDrashRelease = await DenoService.getLatestThirdPartyRelease("drash")
+
 // Check a specific dep that can be updated
 Deno.test({
   name: "Check | Single | Modules to Update Exist",
@@ -118,7 +120,7 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Comparing versions...\n" +
-        colours.yellow("drash can be updated from v1.0.0 to v1.2.1") + "\n" +
+        colours.yellow(`drash can be updated from v1.0.0 to ${latestDrashRelease}`) + "\n" +
         colours.yellow(
           `fs can be updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
         ) +
@@ -203,13 +205,13 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Comparing versions...\n" +
-        colours.yellow("drash can be updated from v1.0.0 to v1.2.1") + "\n" +
+        colours.yellow(`drash can be updated from v1.0.0 to ${latestDrashRelease}`) + "\n" +
         colours.yellow(
           `fs can be updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
         ) +
         "\n" +
         colours.yellow(
-          `fmt can be updated from v0.53.0 to v${DenoService.getLatestStdRelease()}`,
+          `fmt can be updated from 0.53.0 to v${DenoService.getLatestStdRelease()}`,
         ) + "\n" +
         "To update, run: \n" +
         "    dmm update drash fs fmt" +

--- a/tests/check_test.ts
+++ b/tests/check_test.ts
@@ -1,7 +1,9 @@
 import { assertEquals, colours } from "../deps.ts";
 import DenoService from "../src/services/deno_service.ts";
 
-const latestDrashRelease = await DenoService.getLatestThirdPartyRelease("drash")
+const latestDrashRelease = await DenoService.getLatestThirdPartyRelease(
+  "drash",
+);
 
 // Check a specific dep that can be updated
 Deno.test({
@@ -120,7 +122,9 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Comparing versions...\n" +
-        colours.yellow(`drash can be updated from v1.0.0 to ${latestDrashRelease}`) + "\n" +
+        colours.yellow(
+          `drash can be updated from v1.0.0 to ${latestDrashRelease}`,
+        ) + "\n" +
         colours.yellow(
           `fs can be updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
         ) +
@@ -205,7 +209,9 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Comparing versions...\n" +
-        colours.yellow(`drash can be updated from v1.0.0 to ${latestDrashRelease}`) + "\n" +
+        colours.yellow(
+          `drash can be updated from v1.0.0 to ${latestDrashRelease}`,
+        ) + "\n" +
         colours.yellow(
           `fs can be updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
         ) +

--- a/tests/out-of-date-deps/deps.ts
+++ b/tests/out-of-date-deps/deps.ts
@@ -2,6 +2,6 @@ import { Drash } from "https://deno.land/x/drash@v1.0.0/mod.ts"; // out of date
 
 import * as fs from "https://deno.land/std@0.53.0/fs/mod.ts"; // out of date
 
-import * as colors from "https://deno.land/std@v0.53.0/fmt/colors.ts"; // out to date
+import * as colors from "https://deno.land/std@0.53.0/fmt/colors.ts"; // out to date
 
 export { Drash, fs, colors };

--- a/tests/out-of-date-deps/original_deps.ts
+++ b/tests/out-of-date-deps/original_deps.ts
@@ -2,6 +2,6 @@ import { Drash } from "https://deno.land/x/drash@v1.0.0/mod.ts"; // out of date
 
 import * as fs from "https://deno.land/std@0.53.0/fs/mod.ts"; // out of date
 
-import * as colors from "https://deno.land/std@v0.53.0/fmt/colors.ts"; // out to date
+import * as colors from "https://deno.land/std@0.53.0/fmt/colors.ts"; // out to date
 
 export { Drash, fs, colors };

--- a/tests/update_test.ts
+++ b/tests/update_test.ts
@@ -2,7 +2,9 @@
 import { assertEquals, colours } from "../deps.ts";
 import DenoService from "../src/services/deno_service.ts";
 
-const latestDrashRelease = await DenoService.getLatestThirdPartyRelease("drash")
+const latestDrashRelease = await DenoService.getLatestThirdPartyRelease(
+  "drash",
+);
 
 /**
  * @param dir eg "out-of-date-deps"
@@ -63,7 +65,9 @@ Deno.test({
     const expected = "Gathering facts...\n" +
       "Reading deps.ts to gather your dependencies...\n" +
       "Checking if your modules can be updated...\n" +
-      colours.green(`fs was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`) + "\n";
+      colours.green(
+        `fs was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
+      ) + "\n";
     assertEquals(
       stdout,
       expected,
@@ -78,7 +82,11 @@ Deno.test({
       Deno.readFileSync("tests/out-of-date-deps/deps.ts"),
     );
     assertEquals(newDepContent !== originalDepContent, true);
-    assertEquals(newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fs`) !== -1, true);
+    assertEquals(
+      newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fs`) !==
+        -1,
+      true,
+    );
     defaultDepsBackToOriginal("out-of-date-deps");
   },
 });
@@ -160,8 +168,12 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Checking if your modules can be updated...\n" +
-        colours.green(`fs was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`) + "\n" +
-        colours.green(`fmt was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`) + "\n",
+        colours.green(
+          `fs was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
+        ) + "\n" +
+        colours.green(
+          `fmt was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
+        ) + "\n",
     );
     assertEquals(stderr, "");
     assertEquals(status.code, 0);
@@ -173,8 +185,16 @@ Deno.test({
       Deno.readFileSync("tests/out-of-date-deps/deps.ts"),
     );
     assertEquals(newDepContent !== originalDepContent, true);
-    assertEquals(newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fs`) !== -1, true);
-    assertEquals(newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fmt`) !== -1, true);
+    assertEquals(
+      newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fs`) !==
+        -1,
+      true,
+    );
+    assertEquals(
+      newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fmt`) !==
+        -1,
+      true,
+    );
     defaultDepsBackToOriginal("out-of-date-deps");
   },
 });
@@ -252,9 +272,14 @@ Deno.test({
     const assertedOutput = "Gathering facts...\n" +
       "Reading deps.ts to gather your dependencies...\n" +
       "Checking if your modules can be updated...\n" +
-      colours.green(`drash was updated from v1.0.0 to ${latestDrashRelease}`) + "\n" +
-      colours.green(`fs was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`) + "\n" +
-      colours.green(`fmt was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`) + "\n";
+      colours.green(`drash was updated from v1.0.0 to ${latestDrashRelease}`) +
+      "\n" +
+      colours.green(
+        `fs was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
+      ) + "\n" +
+      colours.green(
+        `fmt was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
+      ) + "\n";
     assertEquals(stdout, assertedOutput);
     assertEquals(stderr, "");
     assertEquals(status.code, 0);
@@ -266,8 +291,16 @@ Deno.test({
       Deno.readFileSync("tests/out-of-date-deps/deps.ts"),
     );
     assertEquals(newDepContent !== originalDepContent, true);
-    assertEquals(newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fs`) !== -1, true);
-    assertEquals(newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fmt`) !== -1, true);
+    assertEquals(
+      newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fs`) !==
+        -1,
+      true,
+    );
+    assertEquals(
+      newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fmt`) !==
+        -1,
+      true,
+    );
     assertEquals(newDepContent.indexOf("drash@v1.2.1") !== -1, true);
     defaultDepsBackToOriginal("out-of-date-deps");
   },
@@ -346,7 +379,9 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Checking if your modules can be updated...\n" +
-        colours.green(`drash was updated from v1.0.0 to ${latestDrashRelease}`) + "\n",
+        colours.green(
+          `drash was updated from v1.0.0 to ${latestDrashRelease}`,
+        ) + "\n",
     );
     assertEquals(stderr, "");
     assertEquals(status.code, 0);
@@ -440,8 +475,12 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Checking if your modules can be updated...\n" +
-        colours.green(`drash was updated from v1.0.0 to ${latestDrashRelease}`) + "\n" +
-        colours.green(`fmt was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`) + "\n",
+        colours.green(
+          `drash was updated from v1.0.0 to ${latestDrashRelease}`,
+        ) + "\n" +
+        colours.green(
+          `fmt was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
+        ) + "\n",
     );
     assertEquals(stderr, "");
     assertEquals(status.code, 0);
@@ -453,8 +492,15 @@ Deno.test({
       Deno.readFileSync("tests/out-of-date-deps/deps.ts"),
     );
     assertEquals(newDepContent !== originalDepContent, true);
-    assertEquals(newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fmt`) !== -1, true);
-    assertEquals(newDepContent.indexOf(`drash@${latestDrashRelease}`) !== -1, true);
+    assertEquals(
+      newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fmt`) !==
+        -1,
+      true,
+    );
+    assertEquals(
+      newDepContent.indexOf(`drash@${latestDrashRelease}`) !== -1,
+      true,
+    );
     defaultDepsBackToOriginal("out-of-date-deps");
   },
 });
@@ -490,7 +536,9 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Checking if your modules can be updated...\n" +
-        colours.green(`fs was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`) + "\n",
+        colours.green(
+          `fs was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
+        ) + "\n",
     );
     assertEquals(stderr, "");
     assertEquals(status.code, 0);
@@ -502,7 +550,11 @@ Deno.test({
       Deno.readFileSync("tests/out-of-date-deps/deps.ts"),
     );
     assertEquals(newDepContent !== originalDepContent, true);
-    assertEquals(newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fs`) !== -1, true);
+    assertEquals(
+      newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fs`) !==
+        -1,
+      true,
+    );
     defaultDepsBackToOriginal("out-of-date-deps");
   },
 });

--- a/tests/update_test.ts
+++ b/tests/update_test.ts
@@ -1,5 +1,8 @@
 // Update a specific dep that can be updated
 import { assertEquals, colours } from "../deps.ts";
+import DenoService from "../src/services/deno_service.ts";
+
+const latestDrashRelease = await DenoService.getLatestThirdPartyRelease("drash")
 
 /**
  * @param dir eg "out-of-date-deps"
@@ -60,7 +63,7 @@ Deno.test({
     const expected = "Gathering facts...\n" +
       "Reading deps.ts to gather your dependencies...\n" +
       "Checking if your modules can be updated...\n" +
-      colours.green("fs was updated from 0.53.0 to 0.63.0") + "\n";
+      colours.green(`fs was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`) + "\n";
     assertEquals(
       stdout,
       expected,
@@ -75,7 +78,7 @@ Deno.test({
       Deno.readFileSync("tests/out-of-date-deps/deps.ts"),
     );
     assertEquals(newDepContent !== originalDepContent, true);
-    assertEquals(newDepContent.indexOf("std@0.63.0/fs") !== -1, true);
+    assertEquals(newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fs`) !== -1, true);
     defaultDepsBackToOriginal("out-of-date-deps");
   },
 });
@@ -157,8 +160,8 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Checking if your modules can be updated...\n" +
-        colours.green("fs was updated from 0.53.0 to 0.63.0") + "\n" +
-        colours.green("fmt was updated from v0.53.0 to v0.63.0") + "\n",
+        colours.green(`fs was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`) + "\n" +
+        colours.green(`fmt was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`) + "\n",
     );
     assertEquals(stderr, "");
     assertEquals(status.code, 0);
@@ -170,8 +173,8 @@ Deno.test({
       Deno.readFileSync("tests/out-of-date-deps/deps.ts"),
     );
     assertEquals(newDepContent !== originalDepContent, true);
-    assertEquals(newDepContent.indexOf("std@0.63.0/fs") !== -1, true);
-    assertEquals(newDepContent.indexOf("std@v0.63.0/fmt") !== -1, true);
+    assertEquals(newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fs`) !== -1, true);
+    assertEquals(newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fmt`) !== -1, true);
     defaultDepsBackToOriginal("out-of-date-deps");
   },
 });
@@ -249,9 +252,9 @@ Deno.test({
     const assertedOutput = "Gathering facts...\n" +
       "Reading deps.ts to gather your dependencies...\n" +
       "Checking if your modules can be updated...\n" +
-      colours.green("drash was updated from v1.0.0 to v1.2.1") + "\n" +
-      colours.green("fs was updated from 0.53.0 to 0.63.0") + "\n" +
-      colours.green("fmt was updated from v0.53.0 to v0.63.0") + "\n";
+      colours.green(`drash was updated from v1.0.0 to ${latestDrashRelease}`) + "\n" +
+      colours.green(`fs was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`) + "\n" +
+      colours.green(`fmt was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`) + "\n";
     assertEquals(stdout, assertedOutput);
     assertEquals(stderr, "");
     assertEquals(status.code, 0);
@@ -263,8 +266,8 @@ Deno.test({
       Deno.readFileSync("tests/out-of-date-deps/deps.ts"),
     );
     assertEquals(newDepContent !== originalDepContent, true);
-    assertEquals(newDepContent.indexOf("std@0.63.0/fs") !== -1, true);
-    assertEquals(newDepContent.indexOf("std@v0.63.0/fmt") !== -1, true);
+    assertEquals(newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fs`) !== -1, true);
+    assertEquals(newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fmt`) !== -1, true);
     assertEquals(newDepContent.indexOf("drash@v1.2.1") !== -1, true);
     defaultDepsBackToOriginal("out-of-date-deps");
   },
@@ -343,7 +346,7 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Checking if your modules can be updated...\n" +
-        colours.green("drash was updated from v1.0.0 to v1.2.1") + "\n",
+        colours.green(`drash was updated from v1.0.0 to ${latestDrashRelease}`) + "\n",
     );
     assertEquals(stderr, "");
     assertEquals(status.code, 0);
@@ -437,8 +440,8 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Checking if your modules can be updated...\n" +
-        colours.green("drash was updated from v1.0.0 to v1.2.1") + "\n" +
-        colours.green("fmt was updated from v0.53.0 to v0.63.0") + "\n",
+        colours.green(`drash was updated from v1.0.0 to ${latestDrashRelease}`) + "\n" +
+        colours.green(`fmt was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`) + "\n",
     );
     assertEquals(stderr, "");
     assertEquals(status.code, 0);
@@ -450,8 +453,8 @@ Deno.test({
       Deno.readFileSync("tests/out-of-date-deps/deps.ts"),
     );
     assertEquals(newDepContent !== originalDepContent, true);
-    assertEquals(newDepContent.indexOf("std@v0.63.0/fmt") !== -1, true);
-    assertEquals(newDepContent.indexOf("drash@v1.2.1") !== -1, true);
+    assertEquals(newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fmt`) !== -1, true);
+    assertEquals(newDepContent.indexOf(`drash@${DenoService.}`) !== -1, true);
     defaultDepsBackToOriginal("out-of-date-deps");
   },
 });
@@ -487,7 +490,7 @@ Deno.test({
       "Gathering facts...\n" +
         "Reading deps.ts to gather your dependencies...\n" +
         "Checking if your modules can be updated...\n" +
-        colours.green("fs was updated from 0.53.0 to 0.63.0") + "\n",
+        colours.green(`fs was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`) + "\n",
     );
     assertEquals(stderr, "");
     assertEquals(status.code, 0);
@@ -499,7 +502,7 @@ Deno.test({
       Deno.readFileSync("tests/out-of-date-deps/deps.ts"),
     );
     assertEquals(newDepContent !== originalDepContent, true);
-    assertEquals(newDepContent.indexOf("std@0.63.0/fs") !== -1, true);
+    assertEquals(newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fs`) !== -1, true);
     defaultDepsBackToOriginal("out-of-date-deps");
   },
 });

--- a/tests/update_test.ts
+++ b/tests/update_test.ts
@@ -454,7 +454,7 @@ Deno.test({
     );
     assertEquals(newDepContent !== originalDepContent, true);
     assertEquals(newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fmt`) !== -1, true);
-    assertEquals(newDepContent.indexOf(`drash@${DenoService.}`) !== -1, true);
+    assertEquals(newDepContent.indexOf(`drash@${latestDrashRelease}`) !== -1, true);
     defaultDepsBackToOriginal("out-of-date-deps");
   },
 });


### PR DESCRIPTION
**Description**

* Update readme

* Remove `v` in std imports or version strings as this is no longer supported

* Fix logic to get info on modules due to how the registry has changed

* Fix tests following all this

* Dont use hard coded values for latest std and drash release, and instead use existing logic, meaning this is one thing less to update on releases