### PR TITLE
issue-#33-jsdoc-to-tsdoc

### DIFF
--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -2,6 +2,13 @@ import { colours } from "../../deps.ts";
 import IModule from "../interfaces/module.ts";
 import ModuleService from "../services/module_service.ts";
 
+/**
+ * Reads the dependency file(s) and checks if dependencies are out of date
+ *     - If `dependencies` passed in, it will only  check those deps inside the dep file
+ *     - If `dependencies` is empty, checks all
+ *
+ * @param dependencies - A list of dependencies (module names) to check
+ */
 export async function check(dependencies: string[]): Promise<void> {
   // Create objects for each dep, with its name and version
   const modules = await ModuleService.constructModulesDataFromDeps(

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -1,7 +1,13 @@
 import { colours } from "../../deps.ts";
 import DenoService from "../services/deno_service.ts";
 
-export async function info(modules: string[]) {
+/**
+ * Supplies information on the given module in the first
+ * index of `modules`
+ *
+ * @param modules - List of modules to get info on. Currently, we only support 1, so `modules[0]` will be used
+ */
+export async function info(modules: string[]): Promise<void> {
   if (modules.length === 0 || modules.length > 1) {
     console.error(
       colours.red(

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -2,6 +2,13 @@ import { colours } from "../../deps.ts";
 import IModule from "../interfaces/module.ts";
 import ModuleService from "../services/module_service.ts";
 
+/**
+ * Reads users deps file and will update based on:
+ *     - if `dependencies` has items, only update those in users deps file
+ *     - if `dependencies` is empty, update all
+ *
+ * @param dependencies - List of dependencies the user wishes to update
+ */
 export async function update(dependencies: string[]): Promise<void> {
   // Create objects for each dep, with its name and version
   const modules = await ModuleService.constructModulesDataFromDeps(

--- a/src/interfaces/module.ts
+++ b/src/interfaces/module.ts
@@ -1,3 +1,25 @@
+/**
+ * std
+ *     Is the module std?
+ *
+ * name
+ *     Name of the module
+ *
+ * importedVersion
+ *     The version imported for the given module
+ *
+ * denoLandURL
+ *     The https://deno.land/x/ URL to the module
+ *
+ * githubURL
+ *     The https://github.com/ URL for the module
+ *
+ * latestRelease
+ *     The latest release tag for the module
+ *
+ * description
+ *     Description for the module.
+ */
 export default interface IModule {
   std: boolean;
   name: string;

--- a/src/services/deno_service.ts
+++ b/src/services/deno_service.ts
@@ -10,7 +10,7 @@ interface DenoLandDatabase {
 /**
  * Gets the latest STD release
  */
-const latestStdRelease = await (async function () {
+async function _getLatestStdRelease () {
   const res = await fetch(
       "https://raw.githubusercontent.com/denoland/deno_website2/master/versions.json",
   );
@@ -20,7 +20,8 @@ const latestStdRelease = await (async function () {
   } = await res.json(); // { std: ["0.63.0", ...], cli_to_std: { v1.2.2: "0.63.0", ... } }
   const latestVersion = versions.std[0];
   return latestVersion;
-}())
+}
+const latestStdRelease = await _getLatestStdRelease()
 
 /**
  * @description

--- a/src/services/deno_service.ts
+++ b/src/services/deno_service.ts
@@ -8,14 +8,11 @@ interface DenoLandDatabase {
 }
 
 /**
- * @description
- * Fetches the latest std version
- *
- * @returns {Promise<string>} eg "0.57.0"
+ * Gets the latest STD release
  */
-async function getLatestStdRelease(): Promise<string> {
+const latestStdRelease = await (async function () {
   const res = await fetch(
-    "https://raw.githubusercontent.com/denoland/deno_website2/master/versions.json",
+      "https://raw.githubusercontent.com/denoland/deno_website2/master/versions.json",
   );
   const versions: {
     std: string[];
@@ -23,9 +20,7 @@ async function getLatestStdRelease(): Promise<string> {
   } = await res.json(); // { std: ["0.63.0", ...], cli_to_std: { v1.2.2: "0.63.0", ... } }
   const latestVersion = versions.std[0];
   return latestVersion;
-}
-
-const latestStdRelease = await getLatestStdRelease();
+}())
 
 /**
  * @description
@@ -69,10 +64,9 @@ export default class DenoService {
   }
 
   /**
-   * @description
    * Get the latest std release version
    *
-   * @returns {string} eg "0.57.0"
+   * @returns The latest release eg "0.57.0"
    */
   public static getLatestStdRelease(): string {
     return latestStdRelease;

--- a/src/services/deno_service.ts
+++ b/src/services/deno_service.ts
@@ -10,9 +10,9 @@ interface DenoLandDatabase {
 /**
  * Gets the latest STD release
  */
-async function _getLatestStdRelease () {
+async function _getLatestStdRelease() {
   const res = await fetch(
-      "https://raw.githubusercontent.com/denoland/deno_website2/master/versions.json",
+    "https://raw.githubusercontent.com/denoland/deno_website2/master/versions.json",
   );
   const versions: {
     std: string[];
@@ -21,7 +21,7 @@ async function _getLatestStdRelease () {
   const latestVersion = versions.std[0];
   return latestVersion;
 }
-const latestStdRelease = await _getLatestStdRelease()
+const latestStdRelease = await _getLatestStdRelease();
 
 /**
  * @description

--- a/src/services/module_service.ts
+++ b/src/services/module_service.ts
@@ -4,15 +4,14 @@ import DenoService from "../services/deno_service.ts";
 
 export default class ModuleService {
   /**
-   * @description
    * Keeps the latest release string in-line with the imported version.
    * Latest release will contain or lose the "v" prefix to match the
    * imported version
    *
-   * @param {string} importedVersion eg "v1.0.1" or "1.0.1"
-   * @param {string} latestVersion eg "v1.0.1" or "1.0.1"
+   * @param importedVersion - eg "v1.0.1" or "1.0.1"
+   * @param latestVersion - eg "v1.0.1" or "1.0.1"
    *
-   * @returns {string} "v1.0.1" if `importedVersion` is "v1.0.1", else "1.0.1"
+   * @returns The version eg "v1.0.1" if `importedVersion` is "v1.0.1", else "1.0.1"
    */
   private static standardiseVersion(
     importedVersion: string,
@@ -35,17 +34,16 @@ export default class ModuleService {
   }
 
   /**
-   * @description
    * Constructs the object representations for the given modules, that contains all the information about those modules
    * needed to: run any queries on them, or log information about them.
    *     1. Reads `deps.ts` and turns each dependency into a module object
    *     2. Adds a the github url to each object using Deno's database.json and the modules name
    *     3. Adds the latest version to each object using the github url
    *
-   * @param {string[]} modulesForPurpose Specific modules instead of checking all. Leave empty if all
-   * @param {string} purpose The purpose. Purely for logging purposes, eg "check" or "update"
+   * @param modulesForPurpose - Specific modules instead of checking all. Leave empty if all
+   * @param purpose - The purpose. Purely for logging purposes, eg "check" or "update"
    *
-   * @return {Module[]} An array of objects, with each object containing information about each module
+   * @returns An array of objects, with each object containing information about each module
    */
   public static async constructModulesDataFromDeps(
     modulesForPurpose: string[],


### PR DESCRIPTION
Fixes #33 

**Description**

* Updated doc blocks to use tsdoc

* Moved the method `fetchLatestStdRelease` to be directly assigned to `const latestStdRelease`, as it didn't make sense for it to be it's own method