### PR TITLE
Issue #45 permission docs

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -29,7 +29,8 @@ jobs:
       - name: Install
         run: |
           deno install --allow-read='.' --allow-write='deps.ts' --allow-net='cdn.deno.land,api.deno.land' https://deno.land/x/dmm/mod.ts
-          dmm version
+          export PATH="/home/runner/.deno/bin:$PATH"
+          dmm --version
 
   linting:
     strategy:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -28,7 +28,8 @@ jobs:
 
       - name: Install
         run: |
-          deno install --allow-read --allow-run --allow-write --allow-net https://deno.land/x/dmm/mod.ts
+          deno install --allow-read='.' --allow-write='deps.ts' --allow-net='cdn.deno.land,api.deno.land' https://deno.land/x/dmm/mod.ts
+          dmm version
 
   linting:
     strategy:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -26,11 +26,10 @@ jobs:
           deno cache mod.ts
           deno test --allow-read --allow-run --allow-write --allow-net tests/integration
 
-      - name: Install
+      - name: Install and Permissions
         run: |
           deno install --allow-read='.' --allow-write='deps.ts' --allow-net='cdn.deno.land,api.deno.land' mod.ts
-          export PATH="/home/runner/.deno/bin:$PATH"
-          dmm --version
+          /Users/runner/.deno/bin/dmm --version
 
   linting:
     strategy:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install and Permissions
         run: |
           deno install --allow-read='.' --allow-write='deps.ts' --allow-net='cdn.deno.land,api.deno.land' mod.ts
-          /Users/runner/.deno/bin/dmm --version
+          /home/runner/.deno/bin/dmm --version
 
   linting:
     strategy:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -26,11 +26,9 @@ jobs:
           deno cache mod.ts
           deno test --allow-read --allow-run --allow-write --allow-net tests/integration
 
-      - name: Install and Permissions
+      - name: Ensure Permissions Work
         run: |
-          deno install --allow-read='.' --allow-write='deps.ts' --allow-net='cdn.deno.land,api.deno.land' mod.ts
-          /home/runner/.deno/bin/dmm --version
-
+          deno run --allow-read='.' --allow-write='deps.ts' --allow-net='cdn.deno.land,api.deno.land' mod.ts update
   linting:
     strategy:
       matrix:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install
         run: |
-          deno install --allow-read='.' --allow-write='deps.ts' --allow-net='cdn.deno.land,api.deno.land' https://deno.land/x/dmm/mod.ts
+          deno install --allow-read='.' --allow-write='deps.ts' --allow-net='cdn.deno.land,api.deno.land' mod.ts
           export PATH="/home/runner/.deno/bin:$PATH"
           dmm --version
 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@
 
 There are two ways you can use this module: installing it though `deno`, or running it though a URL.
 
-As dmm only needs to read and write to your `deps.ts`, as well as requiring network access for reading Deno's `database.json`, you can restrict the access this module has.
+As dmm only needs to read and write to your `deps.ts`, as well as requiring network access using Deno's CDN and API, you can restrict the access this module has.
 
 *Install*
 ```
-$ deno install --allow-net --allow-read --allow-write https://deno.land/x/dmm@v1.1.4/mod.ts
+$ deno install --allow-net='cdn.deno.land,api.deno.land' --allow-read='.' --allow-write='deps.ts' https://deno.land/x/dmm@v1.1.4/mod.ts
 $ dmm ...
 ```
 
@@ -61,7 +61,7 @@ $ dmm ...
 
 If you are using this method, be sure to use the latest version of dmm in the command below
 ```
-$ deno run <permissions> https://deno.land/x/dmm@v1.1.4/mod.ts ...
+$ deno run --allow-net='cdn.deno.land,api.deno.land' --allow-read='.' --allow-write='deps.ts' https://deno.land/x/dmm@v1.1.4/mod.ts ...
 ```
 
 In the examples below, dmm is installed and we will be using it that way to make the commands easier to read.
@@ -173,7 +173,7 @@ OPTIONS:
         Prints dmm version
 
 EXAMPLE USAGE:
-    Assume you are importing an out of date version of `fs` from `std`.
+    Assume you are importing an out of date version of `fs` from `std`. See [here](#quick-start) for adding further restrictions.
     deno run --allow-net --allow-read https://deno.land/x/dmm@v1.1.4/mod.ts check fs
     deno run --allow-net --allow-read --allow-write https://deno.land/x/dmm@v1.1.4/mod.ts update fs
     deno run --allow-net https://deno.land/x/dmm@v1.1.4/mod.ts info http
@@ -196,14 +196,13 @@ dmm will only read modules that reside on [deno.land](https://deno.land), whethe
     import { red } from "https://deno.land/std@0.56.0/fmt/colors.ts"; // supported
     import { something } from "https://deno.land/x/something@0v1.0.0/mod.ts"; // supported
     ```
-* dmm will only pull 3rd party dependencies where the entrypoint file is `mod.ts`, as this follows best practice
-
+  
 * dmm will read every `from "https://deno.land/..."` line in your `deps.ts` and using the name and version, will convert the dependencies into objects.
 
 * dmm will then retrieve the rest of the required information for later use for each module:
-    * Latest version - for 3rd party modules, it's pulled using `https://github.com/owner/repo/releases/latest`. For `std` modules, it's taken from `https://raw.githubusercontent.com/denoland/deno_website2/master/versions.json`
+    * Latest version - For std and 3rd party, this is pulled using `https://cdn.deno.land`.
     * GitHub URL - Retrieved through the GitHub API
-    * Description - For 3rd party modules, it is also taken from reading Deno's `database.json` file, which holds all modules that display on https://deno.land/x/
+    * Description - For 3rd party modules, it is taken from `https://api.deno.land`. There is currently no way to get descriptions for std modules.
     
 * After this, dmm will run different actions based on the purpose:
 

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -37,7 +37,7 @@ export async function info(modules: string[]): Promise<void> {
   let gitHubUrl;
   let latestVersion;
   if (isStd) {
-    latestVersion = DenoService.getLatestStdRelease();
+    latestVersion = await DenoService.getLatestModuleRelease("std");
     description = "Cannot retrieve descriptions for std modules";
     denoLandUrl = "https://deno.land/std@" + latestVersion + "/" +
       name;
@@ -47,7 +47,7 @@ export async function info(modules: string[]): Promise<void> {
     description = await DenoService.getThirdPartyDescription(name);
     gitHubUrl = "https://github.com/" +
       await DenoService.getThirdPartyRepoAndOwner(name);
-    latestVersion = await DenoService.getLatestThirdPartyRelease(name);
+    latestVersion = await DenoService.getLatestModuleRelease(name);
     denoLandUrl = "https://deno.land/x/" + name + "@" + latestVersion;
   }
   const importLine = "import * as " + name + ' from "' + denoLandUrl + '";';

--- a/src/services/deno_service.ts
+++ b/src/services/deno_service.ts
@@ -1,20 +1,3 @@
-/**
- * Gets the latest STD release
- */
-async function _getLatestStdRelease() {
-  const res = await fetch(
-    "https://raw.githubusercontent.com/denoland/deno_website2/master/versions.json",
-  );
-  const versions: {
-    std: string[];
-    cli: string[];
-    cli_to_std: { [key: string]: string };
-  } = await res.json(); // { std: ["0.63.0", ...], cli: ["v1.2.2", ...], cli_to_std: { v1.2.2: "0.63.0", ... } }
-  const latestVersion = versions.std[0];
-  return latestVersion;
-}
-const latestStdRelease = await _getLatestStdRelease();
-
 export default class DenoService {
   /**
    * Url for Deno's CDN link
@@ -27,13 +10,13 @@ export default class DenoService {
   public static readonly DENO_API_URL: string = "https://api.deno.land/";
 
   /**
-   * Fetches the latest release of a module using deno.land cdn.
+   * Fetches the latest release of a module using deno.land cdn. Includes std as well.
    *
    * @param name - Module name
    *
    * @returns The latest version.
    */
-  public static async getLatestThirdPartyRelease(
+  public static async getLatestModuleRelease(
     name: string,
   ): Promise<string> {
     const res = await fetch(
@@ -42,15 +25,6 @@ export default class DenoService {
     const json: { latest: string; versions: string[] } = await res.json();
     const latestRelease = json.latest;
     return latestRelease;
-  }
-
-  /**
-   * Get the latest std release version
-   *
-   * @returns The latest release eg "0.57.0"
-   */
-  public static getLatestStdRelease(): string {
-    return latestStdRelease;
   }
 
   /**
@@ -97,7 +71,7 @@ export default class DenoService {
   public static async getThirdPartyRepoAndOwner(
     importedModuleName: string,
   ): Promise<string> {
-    const latestRelease = await DenoService.getLatestThirdPartyRelease(
+    const latestRelease = await DenoService.getLatestModuleRelease(
       importedModuleName,
     );
     const res = await fetch(

--- a/src/services/module_service.ts
+++ b/src/services/module_service.ts
@@ -112,7 +112,7 @@ export default class ModuleService {
       const latestRelease: string = std === true
         ? ModuleService.standardiseVersion(
           importedVersion,
-              await DenoService.getLatestModuleRelease("std"),
+          await DenoService.getLatestModuleRelease("std"),
         )
         : ModuleService.standardiseVersion(
           importedVersion,

--- a/src/services/module_service.ts
+++ b/src/services/module_service.ts
@@ -112,11 +112,11 @@ export default class ModuleService {
       const latestRelease: string = std === true
         ? ModuleService.standardiseVersion(
           importedVersion,
-          DenoService.getLatestStdRelease(),
+              await DenoService.getLatestModuleRelease("std"),
         )
         : ModuleService.standardiseVersion(
           importedVersion,
-          await DenoService.getLatestThirdPartyRelease(name),
+          await DenoService.getLatestModuleRelease(name),
         );
 
       // Get the description

--- a/tests/deps.ts
+++ b/tests/deps.ts
@@ -1,1 +1,0 @@
-export { Rhum } from

--- a/tests/integration/check_test.ts
+++ b/tests/integration/check_test.ts
@@ -222,7 +222,7 @@ Deno.test({
           `fmt can be updated from 0.53.0 to ${latestStdRelease}`,
         ) + "\n" +
         colours.yellow(
-          `uuid can be updated from 0.61.0 to ${DenoService.getLatestStdRelease()}`,
+          `uuid can be updated from 0.61.0 to ${latestStdRelease}`,
         ) + "\n" +
         "To update, run: \n" +
         "    dmm update drash fs fmt uuid" +

--- a/tests/integration/check_test.ts
+++ b/tests/integration/check_test.ts
@@ -5,7 +5,7 @@ import { upToDateDepsDir, outOfDateDepsDir } from "./test_constants.ts";
 const latestDrashRelease = await DenoService.getLatestModuleRelease(
   "drash",
 );
-const latestStdRelease  = await DenoService.getLatestModuleRelease("std");
+const latestStdRelease = await DenoService.getLatestModuleRelease("std");
 
 // Check a specific dep that can be updated
 Deno.test({

--- a/tests/integration/check_test.ts
+++ b/tests/integration/check_test.ts
@@ -2,9 +2,10 @@ import { assertEquals, colours } from "../../deps.ts";
 import DenoService from "../../src/services/deno_service.ts";
 import { upToDateDepsDir, outOfDateDepsDir } from "./test_constants.ts";
 
-const latestDrashRelease = await DenoService.getLatestThirdPartyRelease(
+const latestDrashRelease = await DenoService.getLatestModuleRelease(
   "drash",
 );
+const latestStdRelease  = await DenoService.getLatestModuleRelease("std");
 
 // Check a specific dep that can be updated
 Deno.test({
@@ -39,7 +40,7 @@ Deno.test({
         "Reading deps.ts to gather your dependencies...\n" +
         "Comparing versions...\n" +
         colours.yellow(
-          `fs can be updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
+          `fs can be updated from 0.53.0 to ${latestStdRelease}`,
         ) +
         "\n" +
         "To update, run: \n" +
@@ -127,7 +128,7 @@ Deno.test({
           `drash can be updated from v1.0.0 to ${latestDrashRelease}`,
         ) + "\n" +
         colours.yellow(
-          `fs can be updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
+          `fs can be updated from 0.53.0 to ${latestStdRelease}`,
         ) +
         "\n" +
         "To update, run: \n" +
@@ -214,11 +215,11 @@ Deno.test({
           `drash can be updated from v1.0.0 to ${latestDrashRelease}`,
         ) + "\n" +
         colours.yellow(
-          `fs can be updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
+          `fs can be updated from 0.53.0 to ${latestStdRelease}`,
         ) +
         "\n" +
         colours.yellow(
-          `fmt can be updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
+          `fmt can be updated from 0.53.0 to ${latestStdRelease}`,
         ) + "\n" +
         "To update, run: \n" +
         "    dmm update drash fs fmt" +

--- a/tests/integration/info_test.ts
+++ b/tests/integration/info_test.ts
@@ -1,9 +1,10 @@
 import { assertEquals, colours } from "../../deps.ts";
 import DenoService from "../../src/services/deno_service.ts";
 import { upToDateDepsDir, outOfDateDepsDir } from "./test_constants.ts";
-const latestDrashRelease = await DenoService.getLatestThirdPartyRelease(
+const latestDrashRelease = await DenoService.getLatestModuleRelease(
   "drash",
 );
+const latestStdRelease = await DenoService.getLatestModuleRelease("std");
 
 // Check a specific dep that can be updated
 Deno.test({
@@ -98,10 +99,10 @@ Deno.test({
         "\n" +
         "  - Name: fs\n" +
         "  - Description: Cannot retrieve descriptions for std modules\n" +
-        `  - deno.land Link: https://deno.land/std@${DenoService.getLatestStdRelease()}/fs\n` +
+        `  - deno.land Link: https://deno.land/std@${latestStdRelease}/fs\n` +
         "  - GitHub Repository: https://github.com/denoland/deno/tree/master/std/fs\n" +
-        `  - Import Statement: import * as fs from \"https://deno.land/std@${DenoService.getLatestStdRelease()}/fs\";\n` +
-        `  - Latest Version: ${DenoService.getLatestStdRelease()}\n` +
+        `  - Import Statement: import * as fs from \"https://deno.land/std@${latestStdRelease}/fs\";\n` +
+        `  - Latest Version: ${latestStdRelease}\n` +
         "\n",
     );
     assertEquals(stderr, "");

--- a/tests/integration/update_test.ts
+++ b/tests/integration/update_test.ts
@@ -289,9 +289,9 @@ Deno.test({
       colours.green(
         `fmt was updated from 0.53.0 to ${latestStdRelease}`,
       ) + "\n" +
-        colours.green(
-            `uuid was updated from 0.61.0 to ${latestStdRelease}`,
-        ) + "\n";
+      colours.green(
+        `uuid was updated from 0.61.0 to ${latestStdRelease}`,
+      ) + "\n";
     assertEquals(stdout, assertedOutput);
     assertEquals(stderr, "");
     assertEquals(status.code, 0);

--- a/tests/integration/update_test.ts
+++ b/tests/integration/update_test.ts
@@ -10,9 +10,10 @@ import {
   upToDateOriginalDepsFile,
 } from "./test_constants.ts";
 
-const latestDrashRelease = await DenoService.getLatestThirdPartyRelease(
+const latestDrashRelease = await DenoService.getLatestModuleRelease(
   "drash",
 );
+const latestStdRelease = await DenoService.getLatestModuleRelease("std");
 
 /**
  * @param dir eg "out-of-date-deps"
@@ -74,7 +75,7 @@ Deno.test({
       "Reading deps.ts to gather your dependencies...\n" +
       "Checking if your modules can be updated...\n" +
       colours.green(
-        `fs was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
+        `fs was updated from 0.53.0 to ${latestStdRelease}`,
       ) + "\n";
     assertEquals(
       stdout,
@@ -91,7 +92,7 @@ Deno.test({
     );
     assertEquals(newDepContent !== originalDepContent, true);
     assertEquals(
-      newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fs`) !==
+      newDepContent.indexOf(`std@${latestStdRelease}/fs`) !==
         -1,
       true,
     );
@@ -177,10 +178,10 @@ Deno.test({
         "Reading deps.ts to gather your dependencies...\n" +
         "Checking if your modules can be updated...\n" +
         colours.green(
-          `fs was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
+          `fs was updated from 0.53.0 to ${latestStdRelease}`,
         ) + "\n" +
         colours.green(
-          `fmt was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
+          `fmt was updated from 0.53.0 to ${latestStdRelease}`,
         ) + "\n",
     );
     assertEquals(stderr, "");
@@ -194,12 +195,12 @@ Deno.test({
     );
     assertEquals(newDepContent !== originalDepContent, true);
     assertEquals(
-      newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fs`) !==
+      newDepContent.indexOf(`std@${latestStdRelease}/fs`) !==
         -1,
       true,
     );
     assertEquals(
-      newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fmt`) !==
+      newDepContent.indexOf(`std@${latestStdRelease}/fmt`) !==
         -1,
       true,
     );
@@ -283,10 +284,10 @@ Deno.test({
       colours.green(`drash was updated from v1.0.0 to ${latestDrashRelease}`) +
       "\n" +
       colours.green(
-        `fs was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
+        `fs was updated from 0.53.0 to ${latestStdRelease}`,
       ) + "\n" +
       colours.green(
-        `fmt was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
+        `fmt was updated from 0.53.0 to ${latestStdRelease}`,
       ) + "\n";
     assertEquals(stdout, assertedOutput);
     assertEquals(stderr, "");
@@ -300,12 +301,12 @@ Deno.test({
     );
     assertEquals(newDepContent !== originalDepContent, true);
     assertEquals(
-      newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fs`) !==
+      newDepContent.indexOf(`std@${latestStdRelease}/fs`) !==
         -1,
       true,
     );
     assertEquals(
-      newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fmt`) !==
+      newDepContent.indexOf(`std@${latestStdRelease}/fmt`) !==
         -1,
       true,
     );
@@ -493,7 +494,7 @@ Deno.test({
           `drash was updated from v1.0.0 to ${latestDrashRelease}`,
         ) + "\n" +
         colours.green(
-          `fmt was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
+          `fmt was updated from 0.53.0 to ${latestStdRelease}`,
         ) + "\n",
     );
     assertEquals(stderr, "");
@@ -507,7 +508,7 @@ Deno.test({
     );
     assertEquals(newDepContent !== originalDepContent, true);
     assertEquals(
-      newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fmt`) !==
+      newDepContent.indexOf(`std@${latestStdRelease}/fmt`) !==
         -1,
       true,
     );
@@ -551,7 +552,7 @@ Deno.test({
         "Reading deps.ts to gather your dependencies...\n" +
         "Checking if your modules can be updated...\n" +
         colours.green(
-          `fs was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
+          `fs was updated from 0.53.0 to ${latestStdRelease}`,
         ) + "\n",
     );
     assertEquals(stderr, "");
@@ -565,7 +566,7 @@ Deno.test({
     );
     assertEquals(newDepContent !== originalDepContent, true);
     assertEquals(
-      newDepContent.indexOf(`std@${DenoService.getLatestStdRelease()}/fs`) !==
+      newDepContent.indexOf(`std@${latestStdRelease}/fs`) !==
         -1,
       true,
     );


### PR DESCRIPTION
Fixes #45 

**Description**

* Update docs to use more restrictions when using permissions

* Use current logic and cdn.deno.land to get latest std release. The reason for this was we don't have to add 'raw.githubusercontent' into the `--allow-net` permission. Plus, the cdn provides the latest std version so the logic was pretty just pointless extra code

**Other Notes**

* I would need to update dmm on website after this