### PR TITLE
Issue #55 fix version regex

### DIFF
--- a/src/services/module_service.ts
+++ b/src/services/module_service.ts
@@ -74,7 +74,7 @@ export default class ModuleService {
       );
 
       // Get the imported version
-      const importVersionRegex = /(v)?[0-9].+[0-9].+[0-9]/g;
+      const importVersionRegex = /(v)?[0-9\.]+[0-9\.]+[0-9]/g;
       const importVersionRegexResult = dep.match(importVersionRegex);
       const importedVersion: string = importVersionRegexResult !== null &&
           importVersionRegexResult.length > 0

--- a/tests/integration/check_test.ts
+++ b/tests/integration/check_test.ts
@@ -221,7 +221,7 @@ Deno.test({
           `fmt can be updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
         ) + "\n" +
         colours.yellow(
-            `uuid can be updated from 0.61.0 to ${DenoService.getLatestStdRelease()}`
+          `uuid can be updated from 0.61.0 to ${DenoService.getLatestStdRelease()}`,
         ) + "\n" +
         "To update, run: \n" +
         "    dmm update drash fs fmt uuid" +

--- a/tests/integration/check_test.ts
+++ b/tests/integration/check_test.ts
@@ -220,8 +220,11 @@ Deno.test({
         colours.yellow(
           `fmt can be updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
         ) + "\n" +
+        colours.yellow(
+            `uuid can be updated from 0.61.0 to ${DenoService.getLatestStdRelease()}`
+        ) + "\n" +
         "To update, run: \n" +
-        "    dmm update drash fs fmt" +
+        "    dmm update drash fs fmt uuid" +
         "\n",
     );
     assertEquals(status.code, 0);

--- a/tests/integration/out-of-date-deps/deps.ts
+++ b/tests/integration/out-of-date-deps/deps.ts
@@ -4,6 +4,6 @@ import * as fs from "https://deno.land/std@0.53.0/fs/mod.ts"; // out of date
 
 import * as colors from "https://deno.land/std@0.53.0/fmt/colors.ts"; // out to date
 
-export { v4 } from 'https://deno.land/std@0.61.0/uuid/mod.ts';
+export { v4 } from "https://deno.land/std@0.61.0/uuid/mod.ts";
 
 export { Drash, fs, colors };

--- a/tests/integration/out-of-date-deps/deps.ts
+++ b/tests/integration/out-of-date-deps/deps.ts
@@ -4,4 +4,6 @@ import * as fs from "https://deno.land/std@0.53.0/fs/mod.ts"; // out of date
 
 import * as colors from "https://deno.land/std@0.53.0/fmt/colors.ts"; // out to date
 
+export { v4 } from 'https://deno.land/std@0.61.0/uuid/mod.ts';
+
 export { Drash, fs, colors };

--- a/tests/integration/out-of-date-deps/original_deps.ts
+++ b/tests/integration/out-of-date-deps/original_deps.ts
@@ -4,6 +4,6 @@ import * as fs from "https://deno.land/std@0.53.0/fs/mod.ts"; // out of date
 
 import * as colors from "https://deno.land/std@0.53.0/fmt/colors.ts"; // out to date
 
-export { v4 } from 'https://deno.land/std@0.61.0/uuid/mod.ts';
+export { v4 } from "https://deno.land/std@0.61.0/uuid/mod.ts";
 
 export { Drash, fs, colors };

--- a/tests/integration/out-of-date-deps/original_deps.ts
+++ b/tests/integration/out-of-date-deps/original_deps.ts
@@ -4,4 +4,6 @@ import * as fs from "https://deno.land/std@0.53.0/fs/mod.ts"; // out of date
 
 import * as colors from "https://deno.land/std@0.53.0/fmt/colors.ts"; // out to date
 
+export { v4 } from 'https://deno.land/std@0.61.0/uuid/mod.ts';
+
 export { Drash, fs, colors };

--- a/tests/integration/up-to-date-deps/deps.ts
+++ b/tests/integration/up-to-date-deps/deps.ts
@@ -4,6 +4,6 @@ import * as fs from "https://deno.land/std@0.65.0/fs/mod.ts"; // up to date
 
 import * as colors from "https://deno.land/std@0.65.0/fmt/colors.ts"; // up to date
 
-export { v4 } from 'https://deno.land/std@0.65.0/uuid/mod.ts'; // up to date
+export { v4 } from "https://deno.land/std@0.65.0/uuid/mod.ts"; // up to date
 
 export { Drash, fs, colors };

--- a/tests/integration/up-to-date-deps/deps.ts
+++ b/tests/integration/up-to-date-deps/deps.ts
@@ -4,4 +4,6 @@ import * as fs from "https://deno.land/std@0.65.0/fs/mod.ts"; // up to date
 
 import * as colors from "https://deno.land/std@0.65.0/fmt/colors.ts"; // up to date
 
+export { v4 } from 'https://deno.land/std@0.65.0/uuid/mod.ts'; // up to date
+
 export { Drash, fs, colors };

--- a/tests/integration/up-to-date-deps/original_deps.ts
+++ b/tests/integration/up-to-date-deps/original_deps.ts
@@ -4,6 +4,6 @@ import * as fs from "https://deno.land/std@0.65.0/fs/mod.ts"; // up to date
 
 import * as colors from "https://deno.land/std@0.65.0/fmt/colors.ts"; // up to date
 
-export { v4 } from 'https://deno.land/std@0.65.0/uuid/mod.ts'; // up to date
+export { v4 } from "https://deno.land/std@0.65.0/uuid/mod.ts"; // up to date
 
 export { Drash, fs, colors };

--- a/tests/integration/up-to-date-deps/original_deps.ts
+++ b/tests/integration/up-to-date-deps/original_deps.ts
@@ -4,4 +4,6 @@ import * as fs from "https://deno.land/std@0.65.0/fs/mod.ts"; // up to date
 
 import * as colors from "https://deno.land/std@0.65.0/fmt/colors.ts"; // up to date
 
+export { v4 } from 'https://deno.land/std@0.65.0/uuid/mod.ts'; // up to date
+
 export { Drash, fs, colors };

--- a/tests/integration/update_test.ts
+++ b/tests/integration/update_test.ts
@@ -289,7 +289,7 @@ Deno.test({
         `fmt was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
       ) + "\n" +
       colours.green(
-          `uuid was updated from 0.61.0 to ${DenoService.getLatestStdRelease()}`
+        `uuid was updated from 0.61.0 to ${DenoService.getLatestStdRelease()}`,
       ) + "\n";
     assertEquals(stdout, assertedOutput);
     assertEquals(stderr, "");

--- a/tests/integration/update_test.ts
+++ b/tests/integration/update_test.ts
@@ -287,6 +287,9 @@ Deno.test({
       ) + "\n" +
       colours.green(
         `fmt was updated from 0.53.0 to ${DenoService.getLatestStdRelease()}`,
+      ) + "\n" +
+      colours.green(
+          `uuid was updated from 0.61.0 to ${DenoService.getLatestStdRelease()}`
       ) + "\n";
     assertEquals(stdout, assertedOutput);
     assertEquals(stderr, "");


### PR DESCRIPTION
Fixes #55 

**Description**

* In the mentioned issues case, dmm was matching `v4 } from ...` for the imported version regex. To address this, the regex was made stricter to be more precise towards the tags in imports

* Added tests to cover this