### PR TITLE
feat: Added support for nest.land modules 

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,18 @@ There are two ways you can use this module: installing it though `deno`, or runn
 As dmm only needs to read and write to your `deps.ts`, as well as requiring network access using Deno's CDN and API, you can restrict the access this module has.
 
 *Install*
+```sh
+deno install --allow-net='cdn.deno.land,api.deno.land,x.nest.land' --allow-read='.' --allow-write='deps.ts' https://deno.land/x/dmm@v1.1.5/mod.ts
 ```
-$ deno install --allow-net='cdn.deno.land,api.deno.land' --allow-read='.' --allow-write='deps.ts' https://deno.land/x/dmm@v1.1.5/mod.ts
-$ dmm ...
+```sh
+dmm ...
 ```
 
 *Through the URL*
 
 If you are using this method, be sure to use the latest version of dmm in the command below
-```
-$ deno run --allow-net='cdn.deno.land,api.deno.land' --allow-read='.' --allow-write='deps.ts' https://deno.land/x/dmm@v1.1.5/mod.ts ...
+```sh
+deno run --allow-net='cdn.deno.land,api.deno.land,x.nest.land' --allow-read='.' --allow-write='deps.ts' https://deno.land/x/dmm@v1.1.5/mod.ts ...
 ```
 
 In the examples below, dmm is installed and we will be using it that way to make the commands easier to read.
@@ -189,26 +191,26 @@ EXAMPLE USAGE:
 
 # How it Works
 
-dmm will only read modules that reside on [deno.land](https://deno.land), whether they are 3rd party or `std` modules. As long as you are either importing then exporting a module, or only exporting a module, dmm will check that dependency.
+dmm will only read modules that reside on [deno.land](https://deno.land) or [nest.land](https://nest.land), whether they are 3rd party or `std` modules. As long as you are either importing then exporting a module, or only exporting a module, dmm will check that dependency.
 
 * Your dependencies must be versioned. Not versioning your dependencies is bad practice and can lead to many problems in your project, which is why dmm will not support it. For example:
     ```
-    import { red } from "https://deno.land/std@0.56.0/fmt/colors.ts";
+    import { red } from "https://x.nest.land/std@0.56.0/fmt/colors.ts";
                                               ^^^^^^^
     ```
 
 * dmm only supports importing/exporting modules from Deno's registry: [deno.land](https://deno.land), 3rd party or `std`. For example:
     ```
-    import { red } from "https://deno.land/std@0.56.0/fmt/colors.ts"; // supported
+    import { red } from "https://x.nest.land/std@0.56.0/fmt/colors.ts"; // supported
     import { something } from "https://deno.land/x/something@0v1.0.0/mod.ts"; // supported
     ```
 
-* dmm will read every `from "https://deno.land/..."` line in your `deps.ts` and using the name and version, will convert the dependencies into objects.
+* dmm will read every `from "https://deno.land/..."` or `from "https://x.nest.land/..."` line in your `deps.ts` and using the name and version, will convert the dependencies into objects.
 
 * dmm will then retrieve the rest of the required information for later use for each module:
-    * Latest version - For std and 3rd party, this is pulled using `https://cdn.deno.land`.
-    * GitHub URL - Retrieved through the GitHub API
-    * Description - For 3rd party modules, it is taken from `https://api.deno.land`. There is currently no way to get descriptions for std modules.
+    * Latest version - For std and 3rd party, this is pulled using `https://cdn.deno.land` or `https://x.deno.land/api` .
+    * GitHub URL - Fetched from `https://cdn.deno.land` or `https://x.deno.land/api`
+    * Description - For 3rd party modules, it is taken from `https://api.deno.land` or `https://x.deno.land/api`. There is currently no way to get descriptions for std modules.
     
 * After this, dmm will run different actions based on the purpose:
 

--- a/src/interfaces/module.ts
+++ b/src/interfaces/module.ts
@@ -8,11 +8,12 @@
  * importedVersion
  *     The version imported for the given module
  *
- * denoLandURL
- *     The https://deno.land/x/ URL to the module
+ * moduleURL
+ *     The import URL of the module
  *
- * githubURL
- *     The https://github.com/ URL for the module
+ * resposityURL
+ *     The URL for the code repository for the module. 
+ *     This is always a github.com URL for a deno.land module.
  *
  * latestRelease
  *     The latest release tag for the module
@@ -24,8 +25,8 @@ export default interface IModule {
   std: boolean;
   name: string;
   importedVersion: string;
-  denoLandURL: string;
-  githubURL: string;
+  moduleURL: string;
+  repositoryURL: string;
   latestRelease: string;
   description: string;
 }

--- a/src/services/deno_service.ts
+++ b/src/services/deno_service.ts
@@ -87,8 +87,12 @@ export default class DenoService {
     return repository;
   }
 
-  public static async getThirdPartyRepoURL(importedModuleName: string,): Promise<string> {
-    const repoAndOwner = await DenoService.getThirdPartyRepoAndOwner(importedModuleName);
+  public static async getThirdPartyRepoURL(
+    importedModuleName: string,
+  ): Promise<string> {
+    const repoAndOwner = await DenoService.getThirdPartyRepoAndOwner(
+      importedModuleName,
+    );
     return "https://github.com/" + repoAndOwner;
   }
 }

--- a/src/services/deno_service.ts
+++ b/src/services/deno_service.ts
@@ -86,4 +86,9 @@ export default class DenoService {
     const repository = json.upload_options.repository;
     return repository;
   }
+
+  public static async getThirdPartyRepoURL(importedModuleName: string,): Promise<string> {
+    const repoAndOwner = await DenoService.getThirdPartyRepoAndOwner(importedModuleName);
+    return "https://github.com/" + repoAndOwner;
+  }
 }

--- a/src/services/module_service.ts
+++ b/src/services/module_service.ts
@@ -59,18 +59,19 @@ export default class ModuleService {
 
     // Turn lines that import from a url into a nice array
     const listOfDeps: string[] = depsContent.split("\n").filter((line) =>
-      line.indexOf("https://deno.land") !== -1 || line.indexOf("https://x.nest.land") !== -1
+      line.indexOf("https://deno.land") !== -1 ||
+      line.indexOf("https://x.nest.land") !== -1
     );
 
     // Collate data for each module imported
     const modules: Array<IModule> = [];
     for (const dep of listOfDeps) {
-
       const isDeno = dep.indexOf("https://deno.land/") >= 0;
       const isNest = dep.indexOf("https://x.nest.land/") >= 0;
 
       // Get if is std
-      const isStd: boolean = dep.indexOf("https://deno.land/std") >= 0 || dep.indexOf("https://x.nest.land/std") >= 0;
+      const isStd: boolean = dep.indexOf("https://deno.land/std") >= 0 ||
+        dep.indexOf("https://x.nest.land/std") >= 0;
 
       // Get URL
       const moduleURL: string = dep.substring(
@@ -94,14 +95,15 @@ export default class ModuleService {
         Deno.exit(1);
       }
 
-
       const RegistryService = isDeno ? DenoService : NestService;
 
       // Get the module name
       const name: string = isStd
         ? (dep.split("@" + importedVersion + "/")[1]).split("/")[0]
         : dep.substring(
-          dep.lastIndexOf(isDeno ? "https://deno.land/x/" : "https://x.nest.land/") + 20,
+          dep.lastIndexOf(
+            isDeno ? "https://deno.land/x/" : "https://x.nest.land/",
+          ) + 20,
           dep.lastIndexOf("@"),
         );
 
@@ -133,10 +135,8 @@ export default class ModuleService {
           "Descriptions for std modules are not currently supported",
         );
 
-    
-
-       // Save the module
-       modules.push({
+      // Save the module
+      modules.push({
         std: isStd,
         repositoryURL,
         moduleURL,
@@ -145,7 +145,6 @@ export default class ModuleService {
         name,
         description,
       });
-
     }
 
     if (!modules.length) {

--- a/src/services/module_service.ts
+++ b/src/services/module_service.ts
@@ -1,6 +1,7 @@
 import IModule from "../interfaces/module.ts";
 import { colours } from "../../deps.ts";
 import DenoService from "../services/deno_service.ts";
+import NestService from "../services/nest_service.ts";
 
 export default class ModuleService {
   /**
@@ -58,18 +59,22 @@ export default class ModuleService {
 
     // Turn lines that import from a url into a nice array
     const listOfDeps: string[] = depsContent.split("\n").filter((line) =>
-      line.indexOf("https://deno.land") !== -1
+      line.indexOf("https://deno.land") !== -1 || line.indexOf("https://x.nest.land") !== -1
     );
 
     // Collate data for each module imported
     const modules: Array<IModule> = [];
     for (const dep of listOfDeps) {
-      // Get if is std
-      const std: boolean = dep.indexOf("https://deno.land/std") >= 0;
 
-      // Get deno land URL
-      const denoLandURL: string = dep.substring(
-        dep.lastIndexOf("https://deno.land/"),
+      const isDeno = dep.indexOf("https://deno.land/") >= 0;
+      const isNest = dep.indexOf("https://x.nest.land/") >= 0;
+
+      // Get if is std
+      const isStd: boolean = dep.indexOf("https://deno.land/std") >= 0 || dep.indexOf("https://x.nest.land/std") >= 0;
+
+      // Get URL
+      const moduleURL: string = dep.substring(
+        dep.lastIndexOf(isDeno ? "https://deno.land/" : "https://x.nest.land/"),
         dep.lastIndexOf(".ts") + 3, // to include the `.ts`
       );
 
@@ -89,11 +94,14 @@ export default class ModuleService {
         Deno.exit(1);
       }
 
+
+      const RegistryService = isDeno ? DenoService : NestService;
+
       // Get the module name
-      const name: string = std === true
+      const name: string = isStd
         ? (dep.split("@" + importedVersion + "/")[1]).split("/")[0]
         : dep.substring(
-          dep.lastIndexOf("/x/") + 3,
+          dep.lastIndexOf(isDeno ? "https://deno.land/x/" : "https://x.nest.land/") + 20,
           dep.lastIndexOf("@"),
         );
 
@@ -102,40 +110,42 @@ export default class ModuleService {
         continue;
       }
 
-      // Get the github url
-      const githubURL: string = std === true
+      // Get the repository url (always Github for deno.land but could be something else for nest.land)
+      const repositoryURL: string = isStd
         ? "https://github.com/denoland/deno/tree/master/std/" + name
-        : "https://github.com/" +
-          await DenoService.getThirdPartyRepoAndOwner(name);
+        : await RegistryService.getThirdPartyRepoURL(name);
 
       // Get the latest release - make sure the string is the same format as imported version eg using a "v"
-      const latestRelease: string = std === true
+      const latestRelease: string = isStd
         ? ModuleService.standardiseVersion(
           importedVersion,
-          await DenoService.getLatestModuleRelease("std"),
+          await RegistryService.getLatestModuleRelease("std"),
         )
         : ModuleService.standardiseVersion(
           importedVersion,
-          await DenoService.getLatestModuleRelease(name),
+          await RegistryService.getLatestModuleRelease(name),
         );
 
       // Get the description
-      const description: string = std === false
-        ? await DenoService.getThirdPartyDescription(name)
+      const description: string = !isStd
+        ? await RegistryService.getThirdPartyDescription(name)
         : colours.red(
           "Descriptions for std modules are not currently supported",
         );
 
-      // Save the module
-      modules.push({
-        std,
-        githubURL,
-        denoLandURL,
+    
+
+       // Save the module
+       modules.push({
+        std: isStd,
+        repositoryURL,
+        moduleURL,
         latestRelease,
         importedVersion,
         name,
         description,
       });
+
     }
 
     if (!modules.length) {

--- a/src/services/nest_service.ts
+++ b/src/services/nest_service.ts
@@ -1,0 +1,77 @@
+interface nestModule {
+  name: string;
+  normalizedName: string;
+  owner: string;
+  description: string;
+  repository: string;
+  latestVersion: string;
+  latestStableVersion: string;
+  packageUploadNames: string[];
+  locked: boolean | null;
+  malicious: boolean | null;
+  unlisted: boolean;
+  updatedAt: string;
+  createdAt: string;
+}
+
+
+export default class NestService {
+
+  /**
+   * Url for Nest.Land's API link
+   */
+  public static readonly NEST_API_URL: string = "https://x.nest.land/api/";
+
+  /**
+   * Fetches the latest release of a module using nest.land cdn. Includes std as well.
+   *
+   * @param name - Module name
+   *
+   * @returns The latest version.
+   */
+  public static async getLatestModuleRelease(
+    name: string,
+  ): Promise<string> {
+    const res = await fetch(NestService.NEST_API_URL + "package/" + name);
+    const json: nestModule = await res.json();
+    const latestReleaseWithName = json.latestVersion;
+    const latestRelease = latestReleaseWithName.substr(latestReleaseWithName.indexOf("@") + 1)
+    return latestRelease;
+  }
+
+  /**
+   * Fetches the description for a module
+   *
+   *     await getThirdPartyDescription("drash"); // "A REST microframework ..."
+   *
+   * @param importedModuleName - The imported module in which we want to get the description for
+   *
+   * @returns The description
+   */
+  public static async getThirdPartyDescription(
+    importedModuleName: string,
+  ): Promise<string> {
+    const res = await fetch(NestService.NEST_API_URL + "package/" + importedModuleName);
+    const json: nestModule = await res.json();
+    const description = json.description;
+    return description;
+  }
+
+  /**
+   * Fetches the owner and repository name, for the given module
+   *
+   *     await getThirdPartyRepoAndOwner("drash"); // "drashland/nest-drash"
+   *
+   * @param importedModuleName - The imported module in which we want to get the repository for on github
+   *
+   * @returns The owner and repo name, eg "<owner>/<repo>"
+   */
+  public static async getThirdPartyRepoURL(
+    importedModuleName: string,
+  ): Promise<string> {
+    const res = await fetch(NestService.NEST_API_URL + "package/" + importedModuleName);
+    const json: nestModule = await res.json();
+    const repositoryURL = json.repository;
+    return repositoryURL;
+  }
+}

--- a/src/services/nest_service.ts
+++ b/src/services/nest_service.ts
@@ -14,9 +14,7 @@ interface nestModule {
   createdAt: string;
 }
 
-
 export default class NestService {
-
   /**
    * Url for Nest.Land's API link
    */
@@ -35,7 +33,9 @@ export default class NestService {
     const res = await fetch(NestService.NEST_API_URL + "package/" + name);
     const json: nestModule = await res.json();
     const latestReleaseWithName = json.latestVersion;
-    const latestRelease = latestReleaseWithName.substr(latestReleaseWithName.indexOf("@") + 1)
+    const latestRelease = latestReleaseWithName.substr(
+      latestReleaseWithName.indexOf("@") + 1,
+    );
     return latestRelease;
   }
 
@@ -51,7 +51,9 @@ export default class NestService {
   public static async getThirdPartyDescription(
     importedModuleName: string,
   ): Promise<string> {
-    const res = await fetch(NestService.NEST_API_URL + "package/" + importedModuleName);
+    const res = await fetch(
+      NestService.NEST_API_URL + "package/" + importedModuleName,
+    );
     const json: nestModule = await res.json();
     const description = json.description;
     return description;
@@ -69,7 +71,9 @@ export default class NestService {
   public static async getThirdPartyRepoURL(
     importedModuleName: string,
   ): Promise<string> {
-    const res = await fetch(NestService.NEST_API_URL + "package/" + importedModuleName);
+    const res = await fetch(
+      NestService.NEST_API_URL + "package/" + importedModuleName,
+    );
     const json: nestModule = await res.json();
     const repositoryURL = json.repository;
     return repositoryURL;

--- a/tests/integration/check_test.ts
+++ b/tests/integration/check_test.ts
@@ -1,9 +1,13 @@
 import { assertEquals, colours } from "../../deps.ts";
 import DenoService from "../../src/services/deno_service.ts";
+import NestService from "../../src/services/nest_service.ts";
 import { outOfDateDepsDir, upToDateDepsDir } from "./test_constants.ts";
 
 const latestDrashRelease = await DenoService.getLatestModuleRelease(
   "drash",
+);
+const latestCliffyRelease = await NestService.getLatestModuleRelease(
+  "cliffy",
 );
 const latestStdRelease = await DenoService.getLatestModuleRelease("std");
 
@@ -222,10 +226,16 @@ Deno.test({
           `fmt can be updated from 0.53.0 to ${latestStdRelease}`,
         ) + "\n" +
         colours.yellow(
+          `cliffy can be updated from 0.11.2 to ${latestCliffyRelease}`,
+        ) + "\n" +
+        colours.yellow(
+          `log can be updated from 0.53.0 to ${latestStdRelease}`,
+        ) + "\n" +
+        colours.yellow(
           `uuid can be updated from 0.61.0 to ${latestStdRelease}`,
         ) + "\n" +
         "To update, run: \n" +
-        "    dmm update drash fs fmt uuid" +
+        "    dmm update drash fs fmt cliffy log uuid" +
         "\n",
     );
     assertEquals(status.code, 0);

--- a/tests/integration/check_test.ts
+++ b/tests/integration/check_test.ts
@@ -13,7 +13,7 @@ const latestStdRelease = await DenoService.getLatestModuleRelease("std");
 
 // Check a specific dep that can be updated
 Deno.test({
-  name: "Check | Single | Modules to Update Exist",
+  name: "Check | Single | Modules to Update Exist - deno.land/x",
 
   //ignore: true,
   async fn(): Promise<void> {
@@ -58,7 +58,7 @@ Deno.test({
 
 // Check a specific dep that is already up to date
 Deno.test({
-  name: "Check | Single | No Modules to Update",
+  name: "Check | Single | No Modules to Update - deno.land/x",
 
   //ignore: true,
   async fn(): Promise<void> {
@@ -71,6 +71,90 @@ Deno.test({
         "../../../mod.ts",
         "check",
         "fs",
+      ],
+      cwd: upToDateDepsDir,
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const status = await p.status();
+    p.close();
+    const output = await p.output();
+    const stdout = new TextDecoder("utf-8").decode(output);
+    const error = await p.stderrOutput();
+    const stderr = new TextDecoder("utf-8").decode(error);
+    assertEquals(stderr, "");
+    assertEquals(
+      stdout,
+      "Gathering facts...\n" +
+        "Reading deps.ts to gather your dependencies...\n" +
+        "Comparing versions...\n" +
+        colours.green("Your dependencies are up to date") + "\n",
+    );
+    assertEquals(status.code, 0);
+    assertEquals(status.success, true);
+  },
+});
+
+// Check a specific dep that can be updated
+Deno.test({
+  name: "Check | Single | Modules to Update Exist - nest.land",
+
+  //ignore: true,
+  async fn(): Promise<void> {
+    const p = await Deno.run({
+      cmd: [
+        "deno",
+        "run",
+        "--allow-net",
+        "--allow-read",
+        "../../../mod.ts",
+        "check",
+        "cliffy",
+      ],
+      cwd: outOfDateDepsDir,
+      stdout: "piped",
+      stderr: "piped",
+    });
+    const status = await p.status();
+    const output = await p.output();
+    await p.close();
+    const stdout = new TextDecoder("utf-8").decode(output);
+    const error = await p.stderrOutput();
+    const stderr = new TextDecoder("utf-8").decode(error);
+    assertEquals(stderr, "");
+    assertEquals(
+      stdout,
+      "Gathering facts...\n" +
+        "Reading deps.ts to gather your dependencies...\n" +
+        "Comparing versions...\n" +
+        colours.yellow(
+          `cliffy can be updated from 0.11.2 to ${latestCliffyRelease}`,
+        ) +
+        "\n" +
+        "To update, run: \n" +
+        "    dmm update cliffy" +
+        "\n",
+    );
+    assertEquals(status.code, 0);
+    assertEquals(status.success, true);
+  },
+});
+
+// Check a specific dep that is already up to date
+Deno.test({
+  name: "Check | Single | No Modules to Update - nest.land",
+
+  //ignore: true,
+  async fn(): Promise<void> {
+    const p = await Deno.run({
+      cmd: [
+        "deno",
+        "run",
+        "--allow-net",
+        "--allow-read",
+        "../../../mod.ts",
+        "check",
+        "cliffy",
       ],
       cwd: upToDateDepsDir,
       stdout: "piped",

--- a/tests/integration/out-of-date-deps/deps.ts
+++ b/tests/integration/out-of-date-deps/deps.ts
@@ -4,10 +4,10 @@ import * as fs from "https://deno.land/std@0.53.0/fs/mod.ts"; // out of date
 
 import * as colors from "https://deno.land/std@0.53.0/fmt/colors.ts"; //out of date
 
-import * as Cliffy  from "https://x.nest.land/cliffy@0.11.2/mod.ts"; //out of date
+import * as Cliffy from "https://x.nest.land/cliffy@0.11.2/mod.ts"; //out of date
 
 import * as log from "https://x.nest.land/std@0.53.0/log/mod.ts"; //out of date
 
 export { v4 } from "https://x.nest.land/std@0.61.0/uuid/mod.ts"; //out of date
 
-export { colors, log, fs, Drash, Cliffy};
+export { Cliffy, colors, Drash, fs, log };

--- a/tests/integration/out-of-date-deps/deps.ts
+++ b/tests/integration/out-of-date-deps/deps.ts
@@ -2,8 +2,12 @@ import { Drash } from "https://deno.land/x/drash@v1.0.0/mod.ts"; // out of date
 
 import * as fs from "https://deno.land/std@0.53.0/fs/mod.ts"; // out of date
 
-import * as colors from "https://deno.land/std@0.53.0/fmt/colors.ts"; // out to date
+import * as colors from "https://deno.land/std@0.53.0/fmt/colors.ts"; //out of date
 
-export { v4 } from "https://deno.land/std@0.61.0/uuid/mod.ts";
+import * as Cliffy  from "https://x.nest.land/cliffy@0.11.2/mod.ts"; //out of date
 
-export { colors, Drash, fs };
+import * as log from "https://x.nest.land/std@0.53.0/log/mod.ts"; //out of date
+
+export { v4 } from "https://x.nest.land/std@0.61.0/uuid/mod.ts"; //out of date
+
+export { colors, log, fs, Drash, Cliffy};

--- a/tests/integration/out-of-date-deps/original_deps.ts
+++ b/tests/integration/out-of-date-deps/original_deps.ts
@@ -4,10 +4,10 @@ import * as fs from "https://deno.land/std@0.53.0/fs/mod.ts"; // out of date
 
 import * as colors from "https://deno.land/std@0.53.0/fmt/colors.ts"; //out of date
 
-import * as Cliffy  from "https://x.nest.land/cliffy@0.11.2/mod.ts"; //out of date
+import * as Cliffy from "https://x.nest.land/cliffy@0.11.2/mod.ts"; //out of date
 
 import * as log from "https://x.nest.land/std@0.53.0/log/mod.ts"; //out of date
 
 export { v4 } from "https://x.nest.land/std@0.61.0/uuid/mod.ts"; //out of date
 
-export { colors, log, fs, Drash, Cliffy};
+export { Cliffy, colors, Drash, fs, log };

--- a/tests/integration/out-of-date-deps/original_deps.ts
+++ b/tests/integration/out-of-date-deps/original_deps.ts
@@ -2,8 +2,12 @@ import { Drash } from "https://deno.land/x/drash@v1.0.0/mod.ts"; // out of date
 
 import * as fs from "https://deno.land/std@0.53.0/fs/mod.ts"; // out of date
 
-import * as colors from "https://deno.land/std@0.53.0/fmt/colors.ts"; // out to date
+import * as colors from "https://deno.land/std@0.53.0/fmt/colors.ts"; //out of date
 
-export { v4 } from "https://deno.land/std@0.61.0/uuid/mod.ts";
+import * as Cliffy  from "https://x.nest.land/cliffy@0.11.2/mod.ts"; //out of date
 
-export { colors, Drash, fs };
+import * as log from "https://x.nest.land/std@0.53.0/log/mod.ts"; //out of date
+
+export { v4 } from "https://x.nest.land/std@0.61.0/uuid/mod.ts"; //out of date
+
+export { colors, log, fs, Drash, Cliffy};

--- a/tests/integration/up-to-date-deps/deps.ts
+++ b/tests/integration/up-to-date-deps/deps.ts
@@ -4,10 +4,10 @@ import * as fs from "https://deno.land/std@0.74.0/fs/mod.ts"; // up to date
 
 import * as colors from "https://deno.land/std@0.74.0/fmt/colors.ts"; //up to date
 
-import * as Cliffy  from "https://x.nest.land/cliffy@0.14.3/mod.ts"; //up to date
+import * as Cliffy from "https://x.nest.land/cliffy@0.14.3/mod.ts"; //up to date
 
 import * as log from "https://x.nest.land/std@0.74.0/log/mod.ts"; //up to date
 
 export { v4 } from "https://x.nest.land/std@0.74.0/uuid/mod.ts"; //up to date
 
-export { colors, log, fs, Drash, Cliffy};
+export { Cliffy, colors, Drash, fs, log };

--- a/tests/integration/up-to-date-deps/deps.ts
+++ b/tests/integration/up-to-date-deps/deps.ts
@@ -2,8 +2,12 @@ import { Drash } from "https://deno.land/x/drash@v1.2.5/mod.ts"; // up to date
 
 import * as fs from "https://deno.land/std@0.74.0/fs/mod.ts"; // up to date
 
-import * as colors from "https://deno.land/std@0.74.0/fmt/colors.ts"; // up to date
+import * as colors from "https://deno.land/std@0.74.0/fmt/colors.ts"; //up to date
 
-export { v4 } from "https://deno.land/std@0.74.0/uuid/mod.ts"; // up to date
+import * as Cliffy  from "https://x.nest.land/cliffy@0.14.3/mod.ts"; //up to date
 
-export { colors, Drash, fs };
+import * as log from "https://x.nest.land/std@0.74.0/log/mod.ts"; //up to date
+
+export { v4 } from "https://x.nest.land/std@0.74.0/uuid/mod.ts"; //up to date
+
+export { colors, log, fs, Drash, Cliffy};

--- a/tests/integration/up-to-date-deps/original_deps.ts
+++ b/tests/integration/up-to-date-deps/original_deps.ts
@@ -4,10 +4,10 @@ import * as fs from "https://deno.land/std@0.74.0/fs/mod.ts"; // up to date
 
 import * as colors from "https://deno.land/std@0.74.0/fmt/colors.ts"; //up to date
 
-import * as Cliffy  from "https://x.nest.land/cliffy@0.14.3/mod.ts"; //up to date
+import * as Cliffy from "https://x.nest.land/cliffy@0.14.3/mod.ts"; //up to date
 
 import * as log from "https://x.nest.land/std@0.74.0/log/mod.ts"; //up to date
 
 export { v4 } from "https://x.nest.land/std@0.74.0/uuid/mod.ts"; //up to date
 
-export { colors, log, fs, Drash, Cliffy};
+export { Cliffy, colors, Drash, fs, log };

--- a/tests/integration/up-to-date-deps/original_deps.ts
+++ b/tests/integration/up-to-date-deps/original_deps.ts
@@ -2,8 +2,12 @@ import { Drash } from "https://deno.land/x/drash@v1.2.5/mod.ts"; // up to date
 
 import * as fs from "https://deno.land/std@0.74.0/fs/mod.ts"; // up to date
 
-import * as colors from "https://deno.land/std@0.74.0/fmt/colors.ts"; // up to date
+import * as colors from "https://deno.land/std@0.74.0/fmt/colors.ts"; //up to date
 
-export { v4 } from "https://deno.land/std@0.74.0/uuid/mod.ts"; // up to date
+import * as Cliffy  from "https://x.nest.land/cliffy@0.14.3/mod.ts"; //up to date
 
-export { colors, Drash, fs };
+import * as log from "https://x.nest.land/std@0.74.0/log/mod.ts"; //up to date
+
+export { v4 } from "https://x.nest.land/std@0.74.0/uuid/mod.ts"; //up to date
+
+export { colors, log, fs, Drash, Cliffy};

--- a/tests/integration/update_test.ts
+++ b/tests/integration/update_test.ts
@@ -1,6 +1,7 @@
 // Update a specific dep that can be updated
 import { assertEquals, colours } from "../../deps.ts";
 import DenoService from "../../src/services/deno_service.ts";
+import NestService from "../../src/services/nest_service.ts";
 import {
   outOfDateDepsDir,
   outOfDateDepsFile,
@@ -12,6 +13,9 @@ import {
 
 const latestDrashRelease = await DenoService.getLatestModuleRelease(
   "drash",
+);
+const latestCliffyRelease = await NestService.getLatestModuleRelease(
+  "cliffy",
 );
 const latestStdRelease = await DenoService.getLatestModuleRelease("std");
 
@@ -288,6 +292,12 @@ Deno.test({
       ) + "\n" +
       colours.green(
         `fmt was updated from 0.53.0 to ${latestStdRelease}`,
+      ) + "\n" +
+      colours.green(
+        `cliffy was updated from 0.11.2 to ${latestCliffyRelease}`,
+      ) + "\n" +
+      colours.green(
+        `log was updated from 0.53.0 to ${latestStdRelease}`,
       ) + "\n" +
       colours.green(
         `uuid was updated from 0.61.0 to ${latestStdRelease}`,


### PR DESCRIPTION
Fixes #31.  

**Description**

These changes allow the user to update and check x.nest.land dependencies (including `std` ones) using dmm, in the same way that deno.land/x modules are currently handled. 

**Other Notes**

* `dmm info` still only looks for deno.land modules - it could be nice for it to look for a nest.land package as well.
* I changed the module interface a little so that `denoLandURL` is now `moduleURL` and `githubURL` is now `repositoryURL`, so that it isn't as deno.land/x specific.