### PR TITLE
chore: Remove bloat

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        deno: ["1.5.3"]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -18,8 +17,6 @@ jobs:
 
       - name: Install Deno
         uses: denolib/setup-deno@master
-        with:
-          deno-version: ${{ matrix.deno }}
 
       - name: Integration
         run: |
@@ -31,9 +28,6 @@ jobs:
           cd tests/integration/out-of-date-deps
           deno run --allow-read='.' --allow-write='deps.ts' --allow-net='x.nest.land,cdn.deno.land,api.deno.land,raw.githubusercontent.com,github.com,api.github.com' ../../../mod.ts update
   linting:
-    strategy:
-      matrix:
-        deno: ["1.5.3"]
     # Doesn't need to be checked in all OS
     runs-on: ubuntu-latest
 
@@ -42,8 +36,6 @@ jobs:
 
       - name: Install Deno
         uses: denolib/setup-deno@master
-        with:
-          deno-version: ${{ matrix.deno }}
         
       - name: Check Code FMT
         run: deno fmt --check

--- a/README.md
+++ b/README.md
@@ -21,21 +21,7 @@
 
 `dmm` is a Deno module manager. It can update your `deps.ts` file, check if any of your dependencies are out of date, and give you information about any module in the Deno world. Managing your dependencies hasn't been easier.
 
-# Table of Contents
-
-* [Documentation](#documentation)
-* [Features](#features)
-* [Quick Start](#quick-start)
-* [How it Works](#how-it-works)
-* [Mirrors](#mirrors)
-* [Contributing](#contributing)
-* [License](#license)
-
-# Documentation
-
-* [Full Documentation](https://drash.land/dmm/)
-
-# Features
+### Features
 
 * Zero dependencies
 * Easy and simple to use
@@ -47,26 +33,16 @@
 * No variants of `node_modules` and `package.json`
 * No extra configuration around import maps
 
-# Quick Start
+### Getting Started
 
 Get started [here](https://drash.land/dmm/#/#quickstart) with a basic example.
 
-# How It Works
+### How It Works
 
 dmm reads the `deps.ts` file at the current working directory -- checking versioned `import` and `export` statements and checking to see if they can be updated. If any dependency can be updated, it lets you know which ones can be updated; and if you want to update them, dmm will rewrite your `deps.ts` file so that your dependencies reflect their latest versions.
 
 _Note: nest.land may not reflect the latest Deno Standard Modules version immediately after Deno releases a new version. Please keep this in mind when importing your modules via nest.land._
 
-## Mirrors
+---
 
-* https://nest.land/package/dmm
-
-## Contributing
-
-Contributors are welcomed!
-
-Please read through our [contributing guidelines](./.github/CONTRIBUTING.md). Included are directions for opening issues, coding standards, and notes on development.
-
-## License
-
-By contributing your code, you agree to license your contribution under the [MIT License](./LICENSE).
+Want to contribute? Follow the Contributing Guidelines [here](https://github.com/drashland/.github/blob/master/CONTRIBUTING.md). All code is released under the [MIT License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 ---
 
-`dmm` (pronounced "dim") is a Deno module manager. It can update your `deps.ts` file, check if any of your dependencies are out of date, and give you information about any module in the Deno world. Managing your dependencies hasn't been easier.
+`dmm` is a Deno module manager. It can update your `deps.ts` file, check if any of your dependencies are out of date, and give you information about any module in the Deno world. Managing your dependencies hasn't been easier.
 
 # Table of Contents
 
@@ -49,28 +49,7 @@
 
 # Quick Start
 
-There are two ways you can use this module:
-
-1. You can install it through the `deno` command.
-    ```sh
-    $ deno install \
-      --allow-net='cdn.deno.land,api.deno.land,x.nest.land,raw.githubusercontent.com,github.com,api.github.com' \
-      --allow-read='.' \
-      --allow-write='deps.ts' \
-      https://deno.land/x/dmm@v1.3.0/mod.ts
-
-    $ dmm help
-    ````
-
-2. Run it through a URL.
-    ```sh
-    $ deno run \
-      --allow-net='cdn.deno.land,api.deno.land,x.nest.land,raw.githubusercontent.com,github.com,api.github.com' \
-      --allow-read='.' \
-      --allow-write='deps.ts' \
-      https://deno.land/x/dmm@v1.3.0/mod.ts \
-      help
-    ```
+Get started [here](https://drash.land/dmm/#/#quickstart) with a basic example.
 
 # How It Works
 

--- a/console/bumper_ci_service_files.ts
+++ b/console/bumper_ci_service_files.ts
@@ -1,5 +1,3 @@
-import { version } from "../src/commands/version.ts";
-
 export const regexes = {
   const_statements: /version = ".+"/g,
   deps_drash: /drash@v[0-9.]+[0-9.]+[0-9]/g,
@@ -17,58 +15,10 @@ export const preReleaseFiles = [
     replaceWith: `"version": "{{ thisModulesLatestVersion }}"`,
   },
   {
-    filename: "./README.md",
-    replaceTheRegex: regexes.urls,
-    replaceWith: `dmm@v{{ thisModulesLatestVersion }}`,
-  },
-  {
     filename: "./src/commands/version.ts",
     replaceTheRegex: regexes.const_statements,
     replaceWith: `version = "{{ thisModulesLatestVersion }}"`,
   },
-  {
-    filename: "./tests/integration/error_test.ts",
-    replaceTheRegex: regexes.urls,
-    replaceWith: "dmm@v{{ thisModulesLatestVersion }}",
-  },
-  {
-    filename: "./tests/integration/help_test.ts",
-    replaceTheRegex: regexes.urls,
-    replaceWith: "dmm@v{{ thisModulesLatestVersion }}",
-  },
-  {
-    filename: "./tests/integration/info_test.ts",
-    replaceTheRegex: regexes.urls,
-    replaceWith: "dmm@v{{ thisModulesLatestVersion }}",
-  },
-  {
-    filename: "./tests/integration/info_test.ts",
-    replaceTheRegex: regexes.deps_drash,
-    replaceWith: "drash@v{{ latestDrashVersion }}",
-  },
 ];
 
-export const bumperFiles = [
-  {
-    filename: "./tests/integration/up-to-date-deps/original_deps.ts",
-    replaceTheRegex: regexes.deps_std,
-    replaceWith: "std@{{ latestStdVersion }}",
-  },
-  // Yes... this is NOT a deno version file, but we're trying to keep the tests
-  // up to date and it has a Drash version... so gtfo... leave this alone kthx.
-  {
-    filename: "./tests/integration/up-to-date-deps/original_deps.ts",
-    replaceTheRegex: regexes.deps_drash,
-    replaceWith: "drash@v{{ latestDrashVersion }}",
-  },
-  {
-    filename: "./.github/workflows/master.yml",
-    replaceTheRegex: regexes.yml_deno,
-    replaceWith: `deno: ["{{ latestDenoVersion }}"]`,
-  },
-  {
-    filename: "./tests/integration/info_test.ts",
-    replaceTheRegex: regexes.deps_drash,
-    replaceWith: "drash@v{{ latestDrashVersion }}",
-  },
-];
+export const bumperFiles = [];

--- a/tests/data/expected_help_message.ts
+++ b/tests/data/expected_help_message.ts
@@ -1,4 +1,4 @@
-import {version} from "../../src/commands/version.ts";
+import { version } from "../../src/commands/version.ts";
 
 export const expectedHelpMessage = `
 A module manager for Deno.
@@ -43,4 +43,4 @@ EXAMPLE USAGE
     Get information about a module
         dmm info http
 
-`
+`;

--- a/tests/data/expected_help_message.ts
+++ b/tests/data/expected_help_message.ts
@@ -1,0 +1,46 @@
+import {version} from "../../src/commands/version.ts";
+
+export const expectedHelpMessage = `
+A module manager for Deno.
+
+USAGE
+
+    deno install --allow-net='x.nest.land,cdn.deno.land,api.deno.land,raw.githubusercontent.com,github.com,api.github.com' --allow-read='.' --allow-write='deps.ts' https://deno.land/x/dmm@v${version}/mod.ts
+    dmm [SUBCOMMAND]
+
+SUBCOMMANDS
+
+    check [modules]
+        Checks the specified modules for newer version. Will check all if modules are 
+        omitted.
+
+    update [modules]
+        Updates the specified modules to the newest version. Will update all if modules 
+        are omitted.
+
+    info [modules]
+        Displays information about the given modules, be it std or 3rd party. The 3rd 
+        party module must be referenced at https://deno.land/x/
+
+    help, --help
+        Prints the help message
+
+    version, --version
+        Prints the current dmm version
+
+
+EXAMPLE USAGE
+
+    Install dmm
+        deno install --allow-net='x.nest.land,cdn.deno.land,api.deno.land,raw.githubusercontent.com,github.com,api.github.com' --allow-read='.' --allow-write='deps.ts' https://deno.land/x/dmm@v${version}/mod.ts
+
+    Check a single module
+        dmm check fs
+
+    Update a single module
+        dmm update fs
+
+    Get information about a module
+        dmm info http
+
+`

--- a/tests/integration/error_test.ts
+++ b/tests/integration/error_test.ts
@@ -1,6 +1,6 @@
 import { assertEquals, colours } from "../../deps.ts";
 import { outOfDateDepsDir, upToDateDepsDir } from "./test_constants.ts";
-import {expectedHelpMessage} from "../data/expected_help_message.ts";
+import { expectedHelpMessage } from "../data/expected_help_message.ts";
 
 Deno.test({
   name: "No Purpose",

--- a/tests/integration/error_test.ts
+++ b/tests/integration/error_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, colours } from "../../deps.ts";
 import { outOfDateDepsDir, upToDateDepsDir } from "./test_constants.ts";
+import {expectedHelpMessage} from "../data/expected_help_message.ts";
 
 Deno.test({
   name: "No Purpose",
@@ -18,50 +19,7 @@ Deno.test({
     const stderr = new TextDecoder("utf-8").decode(error);
     assertEquals(
       stdout,
-      `
-A module manager for Deno.
-
-USAGE
-
-    deno install --allow-net='x.nest.land,cdn.deno.land,api.deno.land,raw.githubusercontent.com,github.com,api.github.com' --allow-read='.' --allow-write='deps.ts' https://deno.land/x/dmm@v1.3.0/mod.ts
-    dmm [SUBCOMMAND]
-
-SUBCOMMANDS
-
-    check [modules]
-        Checks the specified modules for newer version. Will check all if modules are 
-        omitted.
-
-    update [modules]
-        Updates the specified modules to the newest version. Will update all if modules 
-        are omitted.
-
-    info [modules]
-        Displays information about the given modules, be it std or 3rd party. The 3rd 
-        party module must be referenced at https://deno.land/x/
-
-    help, --help
-        Prints the help message
-
-    version, --version
-        Prints the current dmm version
-
-
-EXAMPLE USAGE
-
-    Install dmm
-        deno install --allow-net='x.nest.land,cdn.deno.land,api.deno.land,raw.githubusercontent.com,github.com,api.github.com' --allow-read='.' --allow-write='deps.ts' https://deno.land/x/dmm@v1.3.0/mod.ts
-
-    Check a single module
-        dmm check fs
-
-    Update a single module
-        dmm update fs
-
-    Get information about a module
-        dmm info http
-
-`,
+      expectedHelpMessage,
     );
     assertEquals(stderr, "");
     assertEquals(status.code, 0);

--- a/tests/integration/help_test.ts
+++ b/tests/integration/help_test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, colours } from "../../deps.ts";
 import { version } from "../../src/commands/version.ts";
 import { outOfDateDepsDir, upToDateDepsDir } from "./test_constants.ts";
+import {expectedHelpMessage} from "../data/expected_help_message.ts";
 
 Deno.test({
   name: "Help",
@@ -20,50 +21,7 @@ Deno.test({
     assertEquals(stderr, "");
     assertEquals(
       stdout,
-      `
-A module manager for Deno.
-
-USAGE
-
-    deno install --allow-net='x.nest.land,cdn.deno.land,api.deno.land,raw.githubusercontent.com,github.com,api.github.com' --allow-read='.' --allow-write='deps.ts' https://deno.land/x/dmm@v1.3.0/mod.ts
-    dmm [SUBCOMMAND]
-
-SUBCOMMANDS
-
-    check [modules]
-        Checks the specified modules for newer version. Will check all if modules are 
-        omitted.
-
-    update [modules]
-        Updates the specified modules to the newest version. Will update all if modules 
-        are omitted.
-
-    info [modules]
-        Displays information about the given modules, be it std or 3rd party. The 3rd 
-        party module must be referenced at https://deno.land/x/
-
-    help, --help
-        Prints the help message
-
-    version, --version
-        Prints the current dmm version
-
-
-EXAMPLE USAGE
-
-    Install dmm
-        deno install --allow-net='x.nest.land,cdn.deno.land,api.deno.land,raw.githubusercontent.com,github.com,api.github.com' --allow-read='.' --allow-write='deps.ts' https://deno.land/x/dmm@v1.3.0/mod.ts
-
-    Check a single module
-        dmm check fs
-
-    Update a single module
-        dmm update fs
-
-    Get information about a module
-        dmm info http
-
-`,
+      expectedHelpMessage,
     );
     assertEquals(status.code, 0);
     assertEquals(status.success, true);

--- a/tests/integration/help_test.ts
+++ b/tests/integration/help_test.ts
@@ -1,7 +1,7 @@
 import { assertEquals, colours } from "../../deps.ts";
 import { version } from "../../src/commands/version.ts";
 import { outOfDateDepsDir, upToDateDepsDir } from "./test_constants.ts";
-import {expectedHelpMessage} from "../data/expected_help_message.ts";
+import { expectedHelpMessage } from "../data/expected_help_message.ts";
 
 Deno.test({
   name: "Help",


### PR DESCRIPTION
## Summary

* Remove quickstart in readme, and instead link to the documentation
* Use latest deno versions in workflows
* Reduce files in bumper script files as some aren't needed
