### PR TITLE
chore: unify drashland readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,55 +1,14 @@
-<p align="center">
-  <img height="200" src="logo.png" alt="Deno Module Manager">
-  <h1 align="center">Deno Module Manager</h1>
-</p>
-<p align="center">
-  <a href="https://github.com/drashland/dmm/releases">
-    <img src="https://img.shields.io/github/release/drashland/dmm.svg?color=bright_green&label=latest">
-  </a>
-  <a href="https://github.com/drashland/dmm/actions">
-    <img src="https://img.shields.io/github/workflow/status/drashland/dmm/master?label=ci">
-  </a>
-  <a href="https://discord.gg/SgejNXq">
-    <img src="https://img.shields.io/badge/chat-on%20discord-blue">
-  </a>
-  <a href="https://rb.gy/5ppdbh">
-    <img src="https://img.shields.io/badge/Tutorials-YouTube-red">
-  </a>
-</p>
+# Dmm
 
----
+[![Latest Release](https://img.shields.io/github/release/drashland/dmm.svg?color=bright_green&label=latest)](https://github.com/drashland/dmm/releases/latest)
+[![CI](https://img.shields.io/github/workflow/status/drashland/dmm/master?label=ci)](https://github.com/drashland/dmm/actions/workflows/master.yml)
 
-`dmm` is a simple CLI tool to bump your dependencies from your `deps.ts` to
-their latest versions.
+<img align="right" src="./logo.png" alt="Drash Land - Dmm logo" height="150" style="max-height: 150px">
 
-### Features
+Dmm is a CLI tool that helps you keep your dependencies up to date.
 
-- Zero 3rd party dependencies
-- Easy and simple to use
-- Will update your dependencies for you
-- Accounts for 3rd party and Deno Standard modules
-- Installation is optional
-- No variants of `node_modules` and `package.json`
-- No extra configuration around import maps
+View the full documentation at https://drash.land/dmm.
 
-### Getting Started
-
-Get started [here](https://drash.land/dmm/#/#quickstart) with a basic example.
-
-### How It Works
-
-dmm reads the `deps.ts` file at the current working directory -- checking
-versioned `import` and `export` statements and checking to see if they can be
-updated. If any dependency can be updated, it lets you know which ones can be
-updated; and if you want to update them, dmm will rewrite your `deps.ts` file so
-that your dependencies reflect their latest versions.
-
-_Note: nest.land may not reflect the latest Deno Standard Modules version
-immediately after Deno releases a new version. Please keep this in mind when
-importing your modules via nest.land._
-
----
-
-Want to contribute? Follow the Contributing Guidelines
-[here](https://github.com/drashland/.github/blob/master/CONTRIBUTING.md). All
-code is released under the [MIT License](./LICENSE).
+In the event the documentation pages are not accessible, please view the raw
+version of the documentation at
+https://github.com/drashland/website-v2/tree/main/docs.


### PR DESCRIPTION
Unifies the README file across the major drashland projects